### PR TITLE
Add v2 upgrade notification, fix subagent config & tweak MCP logging

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -47,6 +47,7 @@ import { initializeEnhancementDecorations } from "./views/enhancementDecorations
 import { clearSystemInfoCache } from "./services/sapSystemInfo"
 import { HeartbeatWatchlist } from "./services/heartbeat/heartbeatWatchlist"
 import { visualizeDependencyGraph } from "./services/dependencyGraph"
+import { checkUpgradeNotification } from "./services/upgradeNotification"
 
 // Import commands to ensure @command decorators are executed
 import "./commands"
@@ -301,6 +302,10 @@ export async function activate(ctx: ExtensionContext): Promise<AbapFsApi> {
     )
   }
   registerChatTools(context)
+
+  // Check for v1 → v2 upgrade and show notification + status bar hint
+  checkUpgradeNotification(context)
+
   const elapsed = new Date().getTime() - startTime
   log(`Activated,pid=${process.pid}, activation time(ms):${elapsed}`)
   return api

--- a/client/src/services/mcpServer.ts
+++ b/client/src/services/mcpServer.ts
@@ -62,13 +62,18 @@ function getMcpSettings(): { autoStart: boolean; port: number; apiKey: string } 
  * Validate the API key from the request Authorization header.
  * Returns true if authentication passes, false otherwise.
  */
+let apiKeyWarningLogged = false
+
 function validateApiKey(req: http.IncomingMessage): boolean {
   const settings = getMcpSettings()
 
   // If no API key is configured, allow access (for backwards compatibility)
-  // but log a warning
+  // but log a warning once per session
   if (!settings.apiKey) {
-    log("No API key configured for the MCP server. Consider configuring a random key and passing it in your MCP client. Allowing anyway..")
+    if (!apiKeyWarningLogged) {
+      log("No API key configured for the MCP server. Consider configuring a random key and passing it in your MCP client. Allowing anyway..")
+      apiKeyWarningLogged = true
+    }
     return true
   }
 

--- a/client/src/services/upgradeNotification.ts
+++ b/client/src/services/upgradeNotification.ts
@@ -1,0 +1,83 @@
+/**
+ * One-time upgrade notification + blinking status bar for new users.
+ */
+
+import * as vscode from "vscode"
+
+const MARKETPLACE_URL =
+  "https://marketplace.visualstudio.com/items?itemName=murbani.vscode-abap-remote-fs"
+
+const STATE_LAST_VERSION = "abapfs.lastVersion"
+const STATE_UPGRADE_DISMISSED = "abapfs.upgradeStatusBarDismissed"
+
+export function checkUpgradeNotification(context: vscode.ExtensionContext): void {
+  const currentVersion: string = context.extension.packageJSON.version ?? "0.0.0"
+  const lastVersion = context.globalState.get<string>(STATE_LAST_VERSION)
+
+  // Always update stored version
+  context.globalState.update(STATE_LAST_VERSION, currentVersion)
+
+  // Trigger for users upgrading from v1.
+  // v1 never stored this key, so undefined means they had v1 (or it's a fresh install).
+  // We skip if they already have a v2 version stored (meaning they've run v2 before).
+  const isUpgradeFromV1 = lastVersion === undefined || lastVersion.startsWith("1.")
+
+  if (!isUpgradeFromV1) return
+
+  // 1) One-time notification
+  showUpgradeNotification()
+
+  // 2) Blinking status bar (unless already dismissed or expired)
+  showBlinkingStatusBar(context)
+}
+
+// ─── Notification ────────────────────────────────────────────────────────────
+
+function showUpgradeNotification(): void {
+  vscode.window
+    .showInformationMessage(
+      "🚀 ABAP Remote FS has been upgraded to v2 with powerful AI features! " +
+        "Simply ask GitHub Copilot (in Agent mode) to tell you about them.",
+      "Open Marketplace Page"
+    )
+    .then(action => {
+      if (action === "Open Marketplace Page") {
+        vscode.env.openExternal(vscode.Uri.parse(MARKETPLACE_URL))
+      }
+    })
+}
+
+// ─── Blinking Status Bar ─────────────────────────────────────────────────────
+
+function showBlinkingStatusBar(context: vscode.ExtensionContext): void {
+  // Already dismissed by click?
+  if (context.globalState.get<boolean>(STATE_UPGRADE_DISMISSED)) return
+
+  // Create status bar item
+  const item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1000)
+  item.command = "abapfs.openUpgradeMarketplace"
+  item.tooltip = "ABAP Remote FS v2 — Click to learn about new AI features or just ask Copilot!"
+  context.subscriptions.push(item)
+
+  // Blink between two states
+  const textOn = "$(rocket) ABAP FS v2 — New AI Features!"
+  const textOff = "$(sparkle) ABAP FS v2 — New AI Features!"
+  let on = true
+
+  item.text = textOn
+  item.show()
+
+  const blinkInterval = setInterval(() => {
+    on = !on
+    item.text = on ? textOn : textOff
+  }, 1500)
+
+  // Command: open marketplace + dismiss permanently
+  const cmd = vscode.commands.registerCommand("abapfs.openUpgradeMarketplace", () => {
+    vscode.env.openExternal(vscode.Uri.parse(MARKETPLACE_URL))
+    context.globalState.update(STATE_UPGRADE_DISMISSED, true)
+    clearInterval(blinkInterval)
+    item.dispose()
+  })
+  context.subscriptions.push(cmd)
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-abap-remote-fs",
   "displayName": "ABAP remote filesystem",
   "description": "Work on your ABAP code straight from the server",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "publisher": "murbani",
   "publishConfig": {
     "access": "restricted",
@@ -3848,9 +3848,23 @@
         },
         "abapfs.subagents.models": {
           "type": "object",
-          "default": {},
+          "default": {
+            "abap-discoverer": "",
+            "abap-reader": "",
+            "abap-creator": "",
+            "abap-visualizer": "",
+            "abap-documenter": "",
+            "abap-usage-analyzer": "",
+            "abap-quality-checker": "",
+            "abap-historian": "",
+            "abap-debugger": "",
+            "abap-troubleshooter": "",
+            "abap-data-analyst": "",
+            "abap-orchestrator": "",
+            "abap-code-reviewer": ""
+          },
           "scope": "resource",
-          "description": "Model selection per agent. Keys are agent IDs (e.g., 'abap-discoverer'), values are model IDs. Configure via 'ABAP FS: Configure Subagents' command.",
+          "description": "Model selection per agent. Keys are agent IDs (e.g., 'abap-discoverer'), values are model IDs. Ask Copilot to configure this.",
           "additionalProperties": {
             "type": "string"
           }


### PR DESCRIPTION
Introduce a one-time v1→v2 upgrade notification and a blinking status bar hint for new v2 users (client/src/services/upgradeNotification.ts). The extension activation now invokes checkUpgradeNotification to show an informational prompt and a persistent status bar item that opens the marketplace and can be dismissed. Reduce MCP server log noise by only warning once per session when no API key is configured (client/src/services/mcpServer.ts). Also bump extension version and add default subagent model entries + a short guidance tweak in package.json.