### PR TITLE
Add Authorization Object Sets (SUSO) support

### DIFF
--- a/client/src/adt/operations/AdtObjectFinder.ts
+++ b/client/src/adt/operations/AdtObjectFinder.ts
@@ -315,6 +315,11 @@ export class AdtObjectFinder {
         picked: previousSelection.includes("SUSO/SO")
       },
       {
+        type: "SUSO/B",
+        label: "Authorization Object Sets",
+        picked: previousSelection.includes("SUSO/B")
+      },
+      {
         type: "SUSC/SC",
         label: "Authorization Object Classes",
         picked: previousSelection.includes("SUSC/SC")

--- a/client/src/services/abapSearchService.ts
+++ b/client/src/services/abapSearchService.ts
@@ -76,7 +76,8 @@ export class searchService {
               "SFBF", // Business Functions
               "SFBS", // Business Function Sets
               "JOBD", // Job Definitions
-              "NROB" // Number Range Objects
+              "NROB", // Number Range Objects
+              "SUSO" // Authorization Object Sets
             ]
 
       for (const type of searchTypes) {

--- a/package.json
+++ b/package.json
@@ -328,7 +328,8 @@
                   "SFBS",
                   "JOBD",
                   "NROB",
-                  "ENHO"
+                  "ENHO",
+                  "SUSO"
                 ]
               },
               "description": "Object types to search for.Must provide type or list of types."


### PR DESCRIPTION
Register the SUSO type across the codebase: add a new "SUSO/B" entry (Authorization Object Sets) to AdtObjectFinder UI with previousSelection handling, include "SUSO" in the abap search types so these objects are searched, and update package.json types list to document SUSO. This enables discovery and searching of Authorization Object Sets.