### PR TITLE
fix: remove setTimeout race condition in dependency graph webview init

### DIFF
--- a/client/src/services/webviewManager.ts
+++ b/client/src/services/webviewManager.ts
@@ -757,10 +757,8 @@ export class WebviewManager {
       })
     }
 
-    // Try sending immediately (usually works)
-    setTimeout(sendInitData, 100)
-
-    // Also send when webview signals ready (backup)
+    // Send initial data when webview signals it is ready
+    // (avoids the race-condition double-send that was caused by setTimeout + ready)
     const readyDisposable = panel.webview.onDidReceiveMessage(msg => {
       if (msg.command === "ready") {
         sendInitData()


### PR DESCRIPTION
The old code fired `sendInitData()` both from `setTimeout(..., 100)` and from the `onDidReceiveMessage('ready')` handler. On fast machines the webview received its initial data twice; on slow/remote connections the timeout fired before the JS was ready and the data was silently dropped.

Fix: remove the `setTimeout` call entirely. The `ready`-event handler is now the sole trigger — one send, at the right time.