### PR TITLE
fix: remove unreachable dead code in tools.ts

### DIFF
--- a/client/src/adt/ai/tools.ts
+++ b/client/src/adt/ai/tools.ts
@@ -1,12 +1,7 @@
 import { ExtensionContext } from "vscode"
-import { SearchTool } from "./search"
-import { UnitTool } from "./unit"
 import { ActivateTool } from "./activate"
 import { registerToolWithRegistry } from "../../services/lm-tools/toolRegistry"
 
 export const registerChatTools = (context: ExtensionContext) => {
   context.subscriptions.push(registerToolWithRegistry("abap_activate", new ActivateTool()))
-  return // duplicates, I guess
-  context.subscriptions.push(registerToolWithRegistry("abap_search", new SearchTool()))
-  context.subscriptions.push(registerToolWithRegistry("abap_unit", new UnitTool()))
 }


### PR DESCRIPTION
The `return // duplicates, I guess` statement on line 9 made the `abap_search` and `abap_unit` registrations permanently unreachable. Those tools are already registered via `registerAllTools()` in `lm-tools/index.ts`.

Changes:
- Remove the `return` guard and the two dead `registerToolWithRegistry` calls below it
- Remove the now-unused `SearchTool` and `UnitTool` imports