### PR TITLE
UX improvements

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -50,6 +50,8 @@ See [MCP Server](#mcp-server-for-external-ai-tools) for setup.
 
 # Installation Steps
 
+Before proceeding, ensure you meet the [Prerequisites](prerequisite.md).
+
 ## 1. Install the extension
 
 1. Press `Ctrl+Shift+X` or Click on the extension icon on the activity bar to open the **Extensions** panel (left sidebar)

--- a/client/src/commands/commands.ts
+++ b/client/src/commands/commands.ts
@@ -224,6 +224,7 @@ export class AdtCommands {
     return openConnectionManager(extensionContext)
   }
 
+
   @command(AbapFsCommands.connect)
   private static async connectAdtServer(selector: any) {
     logTelemetry("command_connect_called")
@@ -231,6 +232,7 @@ export class AdtCommands {
     try {
       const connectionID = selector && selector.connection
       const manager = RemoteManager.get()
+
       const { remote, userCancel } = await manager.selectConnection(connectionID)
       if (!remote)
         if (!userCancel) throw Error("No remote configuration available in settings")
@@ -243,7 +245,8 @@ export class AdtCommands {
 
       await storeTokens()
 
-      workspace.updateWorkspaceFolders(0, 0, {
+      const folderCount = workspace.workspaceFolders?.length ?? 0
+      workspace.updateWorkspaceFolders(folderCount, 0, {
         uri: Uri.parse("adt://" + remote.name),
         name: remote.name + "(ABAP)"
       })
@@ -253,9 +256,44 @@ export class AdtCommands {
       const body = typeof e === "object" && (e as any)?.response?.body
       if (body) log(body)
       const isMissing = (e: any) => !!`${e}`.match("name.*org.freedesktop.secrets")
+      const errStr = caughtToString(e)
+
+      // Recoverable config errors → open Connection Manager with helpful message
+      let configError = ""
+      if (errStr.includes("No remote configuration available")) {
+        configError = "No SAP systems configured yet. Opening Connection Manager to add one."
+      } else if (errStr.includes("Invalid ADTClient configuration")) {
+        configError = name
+          ? `Connection "${name}" is incomplete (missing ADT URL or username). Opening Connection Manager to fix it.`
+          : "Connection is incomplete (missing ADT URL or username). Opening Connection Manager to fix it."
+      }
+
+      if (configError) {
+        window.showInformationMessage(configError)
+        return commands.executeCommand("abapfs.connectionManager")
+      }
+
+      // HTTP errors with user-friendly messages
+      if (errStr.includes("status code 401")) {
+        return window.showErrorMessage(
+          name
+            ? `Authentication failed for "${name}". Check your username/password in Connection Manager.`
+            : `Authentication failed. Check your credentials.`
+        )
+      }
+      if (errStr.includes("status code 503")) {
+        return window.showErrorMessage(
+          name
+            ? `SAP system "${name}" is unreachable (HTTP 503). The ADT endpoint may be down or proxy settings may be incorrect — contact your Basis team.`
+            : `SAP system is unreachable (HTTP 503). The ADT endpoint may be down or proxy settings may be incorrect — contact your Basis team.`
+        )
+      }
+
       const message = isMissing(e)
         ? `Password storage not supported. Please install gnome-keyring or add a password to the connection`
-        : `Failed to connect to ${name}:${caughtToString(e)}`
+        : name
+          ? `Failed to connect to ${name}: ${errStr}`
+          : `Failed to connect: ${errStr}`
       return window.showErrorMessage(message)
     }
   }
@@ -1207,6 +1245,24 @@ export class AdtCommands {
   @command(AbapFsCommands.clearPassword)
   public static async clearPasswordCmd(connectionId?: string) {
     return RemoteManager.get().clearPasswordCmd(connectionId)
+  }
+
+  @command(AbapFsCommands.changePassword)
+  private static async changePasswordCmd() {
+    const manager = RemoteManager.get()
+    const { remote, userCancel } = await manager.selectConnection()
+    if (userCancel || !remote) return
+
+    const newPassword = await window.showInputBox({
+      prompt: `Enter new password for ${remote.name} (user: ${remote.username})`,
+      password: true,
+      ignoreFocusOut: true
+    })
+    if (!newPassword) return
+
+    await manager.clearPassword(remote.name, remote.username)
+    await manager.savePassword(remote.name, remote.username, newPassword)
+    vscode.window.showInformationMessage(`Password updated for "${remote.name}". Reconnect to use the new credentials.`)
   }
 
   private static async createTI(uri: Uri) {

--- a/client/src/commands/registry.ts
+++ b/client/src/commands/registry.ts
@@ -18,6 +18,7 @@ export const AbapFsCommands = {
   selectDB: "abapfs.selectDB",
   showObject: "abapfs.showObject",
   clearPassword: "abapfs.clearPassword",
+  changePassword: "abapfs.changePassword",
   addfavourite: "abapfs.addfavourite",
   deletefavourite: "abapfs.deletefavourite",
   createConnection: "abapfs.createConnection",

--- a/client/src/configuration/sapConnectionManager.ts
+++ b/client/src/configuration/sapConnectionManager.ts
@@ -821,7 +821,7 @@ export class SapConnectionManager {
                         <button id="addCloudBtn" class="btn btn-secondary">☁️ Add Cloud Connection</button>
                         <button id="exportBtn" class="btn btn-secondary">📤 Export Connections</button>
                         <button id="importJsonBtn" class="btn btn-secondary">📥 Import from JSON</button>
-                        <button id="addBtn" class="btn btn-primary">➕ Add Application Server</button>
+                        <button id="addBtn" class="btn btn-primary">➕ Add SAP System</button>
                     </div>
                 </header>
 

--- a/client/src/context.ts
+++ b/client/src/context.ts
@@ -15,6 +15,7 @@ export type AbapFsContexts =
   | "abapfs:blameActive"
   | "abapfs:blameAvailable"
   | "abapfs:activeEditorIsTable"
+  | "abapfs:noSapConnected"
 
 export const setContext = (key: AbapFsContexts, value: unknown) =>
   commands.executeCommand("setContext", key, value)

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -44,7 +44,7 @@ import { DiagramWebviewManager } from "./services/DiagramWebviewManager"
 import { SapSystemValidator } from "./services/sapSystemValidator"
 import { listAdtFeedsCommand } from "./commands/listAdtFeeds"
 import { validateSubagentsOnStartup } from "./services/lm-tools/subagentConfigTool"
-import { initializeMcpServer } from "./services/mcpServer"
+import { initializeMcpServer, startMcpServerCommand } from "./services/mcpServer"
 import { registerChatTools } from "./adt/ai/tools"
 import { initializeEnhancementDecorations } from "./views/enhancementDecorations"
 import { initializeBlameGutter } from "./views/blameGutter"
@@ -56,7 +56,7 @@ import { checkUpgradeNotification } from "./services/upgradeNotification"
 import { registerAbapRepl } from "./repl"
 import { registerAbapNotebooks } from "./notebooks"
 import { showWelcomeWalkthrough } from "./services/walkthroughService"
-import { disableVirtualToolGrouping } from "./services/virtualToolsFix"
+import { registerVirtualToolsFixOnConnect } from "./services/virtualToolsFix"
 import { ObjectPropertyProvider } from "./views/objectProperties"
 import { ObjectSearchViewProvider } from "./views/objectSearchView"
 import { funWindow as window } from "./services/funMessenger"
@@ -142,7 +142,8 @@ export async function activate(ctx: ExtensionContext): Promise<AbapFsApi> {
     DiagramWebviewManager.initialize(context.extensionUri)
     log("🧜‍♀️ Mermaid Webview Manager ready to make your diagrams prettier than your code")
 
-    // Register Language Model Tools for proper AI integration (includes Mermaid tools)
+
+    // Register Language Model Tools
     await registerAllTools(context)
 
     // Register ABAP Cleaner feature
@@ -157,6 +158,8 @@ export async function activate(ctx: ExtensionContext): Promise<AbapFsApi> {
 
     // Initialize MCP Server for external AI clients (Cursor, etc.)
     await initializeMcpServer(context)
+
+    sub.push(commands.registerCommand("abapfs.startMcpServer", () => startMcpServerCommand(context)))
     // Validate and regenerate subagent files if enabled, but only do that in background
     setImmediate(() => validateSubagentsOnStartup(context))
     log("🚀 ABAP FS services are GO! Houston, we have liftoff! 🌙")
@@ -300,6 +303,10 @@ export async function activate(ctx: ExtensionContext): Promise<AbapFsApi> {
   LanguageCommands.start(context)
 
   setContext("abapfs:extensionActive", true)
+  setContext("abapfs:noSapConnected", !(workspace.workspaceFolders?.some(f => f.uri.scheme === ADTSCHEME) ?? false))
+  sub.push(workspace.onDidChangeWorkspaceFolders(() => {
+    setContext("abapfs:noSapConnected", !(workspace.workspaceFolders?.some(f => f.uri.scheme === ADTSCHEME) ?? false))
+  }))
   restoreLocks()
   registerAbapGit(context)
 
@@ -383,12 +390,11 @@ export async function activate(ctx: ExtensionContext): Promise<AbapFsApi> {
     // Non-critical — never break extension activation
   }
 
+  // Register virtual tools fix — fires once on first SAP connection, not at activation
+  registerVirtualToolsFixOnConnect(context)
+
   const elapsed = new Date().getTime() - startTime
   log.debug(`Activated,pid=${process.pid}, activation time(ms):${elapsed}`)
-
-  // Delay the virtual tools fix so VS Code and Copilot are fully loaded
-  // (the reset command is slow during early activation but fast once everything is ready)
-  setTimeout(() => disableVirtualToolGrouping(ctx), 10000)
   return api
 }
 

--- a/client/src/fs/FsProvider.ts
+++ b/client/src/fs/FsProvider.ts
@@ -126,7 +126,7 @@ export class FsProvider implements FileSystemProvider {
       // Don't log FileNotFound errors for method names/debug artifacts to reduce noise
       if (!(e instanceof FileSystemError && e.name === "FileNotFound (FileSystemError)"))
         log.debug(`Error in stat of ${uri?.toString()}\n${caughtToString(e)}`)
-      throw e
+      throw this.wrapHttpError(e, uri)
     }
   }
 
@@ -164,7 +164,7 @@ export class FsProvider implements FileSystemProvider {
       return files
     } catch (e) {
       log(`Error reading directory ${uri?.toString()}\n${caughtToString(e)}`)
-      throw e
+      throw this.wrapHttpError(e, uri)
     }
   }
 
@@ -173,6 +173,20 @@ export class FsProvider implements FileSystemProvider {
     throw FileSystemError.NoPermissions(
       "Not a real filesystem, directory creation is not supported"
     )
+  }
+
+  private wrapHttpError(e: unknown, uri: Uri): unknown {
+    if (e instanceof FileSystemError) return e
+    const msg = caughtToString(e)
+    if (msg.includes("status code 401"))
+      return FileSystemError.NoPermissions(`Authentication failed for ${uri.authority}. Wrong password?`)
+    if (msg.includes("status code 403"))
+      return FileSystemError.NoPermissions(`Access denied to ${uri.authority} (HTTP 403). Likely a proxy issue or ADT service (/sap/bc/adt) not activated in SICF — contact your Basis team.`)
+    if (msg.includes("status code 503"))
+      return FileSystemError.Unavailable(`SAP system ${uri.authority} is unreachable (HTTP 503). ADT endpoint may be down or proxy misconfigured.`)
+    if (msg.includes("status code 404"))
+      return FileSystemError.FileNotFound(uri)
+    return e
   }
 
   private async askOverwrite(uri: Uri) {

--- a/client/src/services/mcpServer.ts
+++ b/client/src/services/mcpServer.ts
@@ -556,6 +556,75 @@ function stopServer(): void {
  * Initialize and start the MCP server based on settings
  * Call this from extension.ts during activation
  */
+
+
+const MCP_COPILOT_DISMISSED_KEY = "abapfs.mcpServer.copilotPromptDismissed"
+
+/**
+ * Start MCP server via command. Shows Copilot warning if applicable.
+ */
+export async function startMcpServerCommand(context: vscode.ExtensionContext): Promise<void> {
+  if (state.isRunning) {
+    window.showInformationMessage(`MCP Server is already running on port ${state.port}.`)
+    return
+  }
+
+
+  // One-time check: if LLM models are available (Copilot active), user may not need MCP
+  const dismissed = context.globalState.get<boolean>(MCP_COPILOT_DISMISSED_KEY)
+  if (!dismissed) {
+    let hasModels = false
+    try {
+      const models = await vscode.lm.selectChatModels({})
+      hasModels = models.length > 0
+    } catch {
+      // No models available — user likely needs MCP for external AI clients
+    }
+
+    if (hasModels) {
+      const selection = await vscode.window.showQuickPick(
+        [
+          { label: "$(rocket) Start MCP Anyway", description: "I use Cursor/Claude/other external AI tools", value: "start" },
+          { label: "$(x) Don't Start", description: "I only use GitHub Copilot — don't need MCP", value: "disable" }
+        ],
+        {
+          placeHolder: "Github Copilot AI models detected. MCP server is for external AI tools — do you still need it?",
+          ignoreFocusOut: true
+        }
+      )
+
+      if (!selection || selection.value === "disable") {
+        await context.globalState.update(MCP_COPILOT_DISMISSED_KEY, true)
+        const config = vscode.workspace.getConfiguration("abapfs.mcpServer")
+        await config.update("autoStart", false, vscode.ConfigurationTarget.Workspace)
+        log("🔌 MCP Server disabled by user — Copilot provides native tool access")
+        return
+      }
+      // "start" selected
+      await context.globalState.update(MCP_COPILOT_DISMISSED_KEY, true)
+    }
+  }
+
+  // Persist autoStart so MCP starts automatically on next VS Code launch
+  if (vscode.workspace.workspaceFolders?.length) {
+    const mcpConfig = vscode.workspace.getConfiguration("abapfs.mcpServer")
+    await mcpConfig.update("autoStart", true, vscode.ConfigurationTarget.Workspace)
+  } else {
+    window.showInformationMessage(
+      "MCP Server started for this session. Open a workspace/folder and start MCP to persist this setting in that workspace across restarts."
+    )
+  }
+
+  try {
+    await startHttpServer()
+    context.subscriptions.push({ dispose: () => { stopServer() } })
+  } catch (error) {
+    window.showWarningMessage(
+      `MCP Server failed to start: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
 export async function initializeMcpServer(context: vscode.ExtensionContext): Promise<void> {
   const settings = getMcpSettings()
 
@@ -563,21 +632,8 @@ export async function initializeMcpServer(context: vscode.ExtensionContext): Pro
     return // Don't start if autoStart is disabled
   }
 
-  try {
-    await startHttpServer()
-
-    // Register cleanup on extension deactivation
-    context.subscriptions.push({
-      dispose: () => {
-        stopServer()
-      }
-    })
-  } catch (error) {
-    // Don't throw - MCP server is optional, extension should still work
-    window.showWarningMessage(
-      `MCP Server failed to start: ${error instanceof Error ? error.message : String(error)}`
-    )
-  }
+  // On autoStart, reuse the same logic (modal + start)
+  await startMcpServerCommand(context)
 }
 
 /**

--- a/client/src/services/upgradeNotification.ts
+++ b/client/src/services/upgradeNotification.ts
@@ -10,6 +10,7 @@ const MARKETPLACE_URL =
 
 const STATE_LAST_VERSION = "abapfs.lastVersion"
 const STATE_UPGRADE_DISMISSED = "abapfs.upgradeStatusBarDismissed"
+const STATE_STATUS_BAR_PENDING = "abapfs.upgradeStatusBarPending"
 
 export function checkUpgradeNotification(context: vscode.ExtensionContext): void {
   const currentVersion: string = context.extension.packageJSON.version ?? "0.0.0"
@@ -23,29 +24,15 @@ export function checkUpgradeNotification(context: vscode.ExtensionContext): void
   // We skip if they already have a v2 version stored (meaning they've run v2 before).
   const isUpgradeFromV1 = lastVersion === undefined || lastVersion.startsWith("1.")
 
-  if (!isUpgradeFromV1) return
+  if (isUpgradeFromV1) {
+    // Mark that we want to show the status bar — persists across reloads until dismissed
+    context.globalState.update(STATE_STATUS_BAR_PENDING, true)
+  }
 
-  // 1) One-time notification
-  showUpgradeNotification()
-
-  // 2) Blinking status bar (unless already dismissed or expired)
-  showBlinkingStatusBar(context)
-}
-
-// ─── Notification ────────────────────────────────────────────────────────────
-
-function showUpgradeNotification(): void {
-  window
-    .showInformationMessage(
-      "🚀 ABAP Remote FS has been upgraded to v2 with powerful AI features! " +
-        "Simply ask GitHub Copilot (in Agent mode) to tell you about them.",
-      "Open Marketplace Page"
-    )
-    .then(action => {
-      if (action === "Open Marketplace Page") {
-        vscode.env.openExternal(vscode.Uri.parse(MARKETPLACE_URL))
-      }
-    })
+  // Show status bar if pending (covers both fresh upgrade and post-reload reactivation)
+  if (context.globalState.get<boolean>(STATE_STATUS_BAR_PENDING)) {
+    showBlinkingStatusBar(context)
+  }
 }
 
 // ─── Blinking Status Bar ─────────────────────────────────────────────────────
@@ -77,6 +64,7 @@ function showBlinkingStatusBar(context: vscode.ExtensionContext): void {
   const cmd = vscode.commands.registerCommand("abapfs.openUpgradeMarketplace", () => {
     vscode.env.openExternal(vscode.Uri.parse(MARKETPLACE_URL))
     context.globalState.update(STATE_UPGRADE_DISMISSED, true)
+    context.globalState.update(STATE_STATUS_BAR_PENDING, false)
     clearInterval(blinkInterval)
     item.dispose()
   })

--- a/client/src/services/virtualToolsFix.ts
+++ b/client/src/services/virtualToolsFix.ts
@@ -5,25 +5,69 @@
  * them into groups that Copilot often fails to activate — making our 30+ ABAP
  * tools invisible. Setting threshold to 0 disables grouping entirely.
  *
- * This runs once on activation. If the threshold is already 0, it stays dormant.
+ * This is triggered once after the user first connects to a SAP system.
+ * It shows a non-modal notification rather than a blocking modal dialog.
  */
 
 import * as vscode from "vscode"
 import { log } from "../lib"
 import { funWindow as window } from "./funMessenger"
+import { ADTSCHEME } from "../adt/conections"
 
 const FULL_SETTING_ID = "github.copilot.chat.virtualTools.threshold"
 const RESET_COMMAND = "github.copilot.debug.resetVirtualToolGroups"
 const DISMISSED_KEY = "abapfs.virtualToolsFix.dismissed"
 
-export async function disableVirtualToolGrouping(
+/**
+ * Called on every activation. Handles two scenarios:
+ * 1. ADT folders already present (extension restarted after connecting) → check after a delay.
+ * 2. No ADT folders yet → register a listener and wait for the first connection.
+ *
+ * Safe to call on every activation — dismissed/already-fixed state is persisted.
+ */
+export function registerVirtualToolsFixOnConnect(context: vscode.ExtensionContext): void {
+  // Already dismissed — nothing to do ever again
+  if (context.globalState.get<boolean>(DISMISSED_KEY)) return
+
+  const hasAdtFolders = vscode.workspace.workspaceFolders?.some(
+    f => f.uri.scheme === ADTSCHEME
+  ) ?? false
+
+  if (hasAdtFolders) {
+    // Extension restarted with ADT folders already mounted (e.g. after connecting).
+    // Delay so the workspace finishes settling before showing the notification.
+    setTimeout(() => disableVirtualToolGrouping(context), 5000)
+    return
+  }
+
+  // No ADT folders yet — wait for the first connection
+  const listener = vscode.workspace.onDidChangeWorkspaceFolders(e => {
+    const hasNewAdtFolder = e.added.some(f => f.uri.scheme === ADTSCHEME)
+    if (!hasNewAdtFolder) return
+
+    listener.dispose()
+    setTimeout(() => disableVirtualToolGrouping(context), 5000)
+  })
+  context.subscriptions.push(listener)
+}
+
+async function disableVirtualToolGrouping(
   context: vscode.ExtensionContext
 ): Promise<void> {
+
   try {
-    // User previously chose "Don't Ask Again" — respect that
-    if (context.globalState.get<boolean>(DISMISSED_KEY)) {
-      return
+    if (context.globalState.get<boolean>(DISMISSED_KEY)) return
+
+    // Only proceed if AI models are available — if not, Copilot isn't active yet
+    // and there's nothing to fix. Will retry automatically on next activation.
+    let hasModels = false
+    try {
+      const models = await vscode.lm.selectChatModels({})
+      hasModels = models.length > 0
+    } catch {
+      // selectChatModels not available or failed — skip silently
     }
+    if (!hasModels) return
 
     const rootConfig = vscode.workspace.getConfiguration()
     const inspection = rootConfig.inspect<number>(FULL_SETTING_ID)
@@ -36,16 +80,13 @@ export async function disableVirtualToolGrouping(
       return // Already disabled — stay dormant
     }
 
-    // Ask the user before changing anything
+    // Non-modal notification — doesn't interrupt the user's workflow
     const selection = await window.showWarningMessage(
-      "VS Code's experimental \"virtual tool grouping\" is active (threshold: "
-        + effectiveValue
-        + "). This groups extension tools and Copilot often fails to activate the groups, "
-        + "making ABAP FS tools invisible to AI. "
-        + "We recommend setting the threshold to 0 to disable grouping so all 30+ ABAP tools are always available to Copilot.",
-      { modal: true, detail: "This changes the setting \"github.copilot.chat.virtualTools.threshold\" to 0 at both global and workspace level. A window reload will be needed afterwards." },
-      "Disable Grouping & Reload",
-      "Remind Me Next Time",
+      `ABAP FS: Virtual tool grouping is active (threshold: ${effectiveValue}). ` +
+        "Copilot may not see all 30+ ABAP tools. " +
+        "Disable grouping to make all tools available?",
+      "Disable & Reload",
+      "Later",
       "Don't Ask Again"
     )
 
@@ -55,27 +96,20 @@ export async function disableVirtualToolGrouping(
       return
     }
 
-    if (selection === "Remind Me Next Time") {
-      log("🔧 User deferred virtual tool grouping fix — will ask again next activation")
+    if (selection !== "Disable & Reload") {
+      log("🔧 User deferred virtual tool grouping fix — will ask again next connection")
       return
     }
 
-    if (selection !== "Disable Grouping & Reload") {
-      // User dismissed the dialog (pressed Escape / clicked X) — same as remind me
-      return
-    }
-
-    // Show progress while applying changes — settings updates trigger config change events across all extensions which takes a moment
+    // Show progress while applying changes
     await window.withProgress(
       { location: vscode.ProgressLocation.Notification, title: "Disabling virtual tool grouping..." },
       async (progress) => {
         progress.report({ message: "Updating settings..." })
 
-        // Always update global
         await rootConfig.update(FULL_SETTING_ID, 0, vscode.ConfigurationTarget.Global)
         log("🔧 Disabled virtual tool grouping at global level")
 
-        // Update workspace level only if a workspace is open — this throws otherwise
         if (vscode.workspace.workspaceFolders?.length) {
           try {
             await rootConfig.update(FULL_SETTING_ID, 0, vscode.ConfigurationTarget.Workspace)
@@ -97,11 +131,11 @@ export async function disableVirtualToolGrouping(
         await vscode.commands.executeCommand("workbench.action.reloadWindow")
       }
     )
+
   } catch (error) {
-    // "Canceled" is expected — the window reload disposes the extension mid-execution
     const msg = String(error)
-    if (!msg.includes("Canceled")) {
-      log(`⚠️ Could not check/disable virtual tool grouping: ${error}`)
-    }
+    if (msg.includes("Canceled")) return
+    // Unexpected error (e.g. settings write failed, reload command unavailable)
+    log(`⚠️ Could not apply virtual tool grouping fix: ${error}`)
   }
 }

--- a/docs/ai/language-model-tools.md
+++ b/docs/ai/language-model-tools.md
@@ -6,6 +6,12 @@ Language Model Tools are the built-in capabilities that GitHub Copilot uses auto
 
 Make sure you are in **Agent mode** (not Ask or Edit) for full tool access.
 
+## Connection Requirement
+
+Most tools require an active SAP connection. When no SAP system is connected, tools are hidden from Copilot to save context tokens. The **abap_fs_documentation** tool is always available regardless of connection status — use it to ask about features and setup.
+
+Connect to a SAP system (`Ctrl+Shift+P` → **ABAP FS: Connect to an ABAP system**) to enable all 40+ tools.
+
 ## How it works
 
 When you type a question, Copilot picks the appropriate tool behind the scenes:

--- a/docs/developer-tools/tool-grouping-fix.md
+++ b/docs/developer-tools/tool-grouping-fix.md
@@ -2,19 +2,25 @@
 
 VS Code has an experimental setting (`github.copilot.chat.virtualTools.threshold`) that collapses extension tools into virtual groups when their count exceeds a threshold. When active, Copilot often fails to discover these groups — making all 39 ABAP FS AI tools invisible and unusable.
 
-ABAP FS detects this condition on startup and prompts you to fix it automatically.
+ABAP FS detects this condition after your first SAP connection and prompts you to fix it.
 
-## What Happens at Startup
+## When the Prompt Appears
 
-If grouping is active, a warning dialog appears with three options:
+The check runs after you first connect to a SAP system (not at extension activation). It only fires when:
+
+- The virtual tools threshold is greater than `0`
+- AI models are available (GitHub Copilot is signed in and active)
+- You haven't previously dismissed the prompt
+
+A non-modal notification appears with three options:
 
 | Option | Effect |
 |---|---|
-| **Disable Grouping & Reload** | Sets the threshold to `0` globally and in your workspace, then reloads VS Code |
-| **Remind Me Next Time** | Skips the prompt this session; asks again next time |
+| **Disable & Reload** | Sets the threshold to `0` globally and in your workspace, then reloads VS Code |
+| **Later** | Skips the prompt this session; asks again on next connection |
 | **Don't Ask Again** | Permanently suppresses the prompt |
 
-Choose **Disable Grouping & Reload** unless you have a specific reason to keep grouping enabled.
+Choose **Disable & Reload** unless you have a specific reason to keep grouping enabled.
 
 ## Fixing It Manually
 

--- a/docs/getting-started/connection-manager.md
+++ b/docs/getting-started/connection-manager.md
@@ -1,5 +1,7 @@
 # SAP Connection Manager
 
+> **Important:** ABAP FS has 40+ AI tools for Copilot, but they are only available once you connect to a SAP system. Use the Connection Manager to add your first system.
+
 The Connection Manager is a visual interface for adding, editing, and organizing your SAP system connections. Open it from the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) by typing **ABAP FS: Connection Manager**.
 
 ## Adding a Connection
@@ -35,6 +37,15 @@ Select multiple connections using the checkboxes to:
 - **Bulk username edit** — update the username across multiple connections simultaneously.
 
 A confirmation dialog appears before any bulk action is applied.
+
+## Password Management
+
+Passwords are stored securely in the OS credential manager (never in settings files).
+
+| Command | What it does |
+|---|---|
+| **ABAP FS: Change Connection Password** | Select a system and enter a new password |
+| **ABAP FS: Forget connection password** | Removes the stored password; you'll be prompted on next connect |
 
 ## User vs. Workspace Settings
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,5 +1,7 @@
 # Installation Steps
 
+Before proceeding, ensure you meet the [Prerequisites](prerequisite.md).
+
 > **Note:** ABAP FS registers 40+ AI tools for Copilot, but only the documentation tool is available until you connect to a SAP system. Connect to SAP first to unlock all tools.
 
 ## 1. Install the extension

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,5 +1,7 @@
 # Installation Steps
 
+> **Note:** ABAP FS registers 40+ AI tools for Copilot, but only the documentation tool is available until you connect to a SAP system. Connect to SAP first to unlock all tools.
+
 ## 1. Install the extension
 
 1. Press `Ctrl+Shift+X` or Click on the extension icon on the activity bar to open the **Extensions** panel (left sidebar)
@@ -12,7 +14,7 @@
 
 1. Press `Ctrl+Shift+P` to open the **Command Palette** (the search bar for VS Code commands)
 2. Type and run: **ABAP FS: Connection Manager**
-3. In the connection manager window, click **Add Connection** and fill in:
+3. In the connection manager window, click **Add SAP System** and fill in:
    - **URL** – your SAP system URL
    - **Client**, **Username**, **Language**
    - SAP GUI settings (optional)
@@ -32,6 +34,11 @@
 2. Select the system you configured
 3. Enter your password if prompted
 4. Wait a moment for VS Code to establish the connection
+
+## Password Management
+
+- **Change password:** `Ctrl+Shift+P` → **ABAP FS: Change Connection Password** — select a system and enter your new password.
+- **Forget password:** `Ctrl+Shift+P` → **ABAP FS: Forget connection password** — removes the stored password so you're prompted again on next connect.
 
 ## 4. Verify the connection
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,8 @@ If you're used to SE38, SE24, or ADT in Eclipse, ABAP FS brings that same direct
 
 ## What you can do
 
+> **Note:** ABAP FS has 40+ AI tools, but only the documentation tool is available until you connect to a SAP system. Add SAP connections using Connection manager and then run `ABAP FS: Connect to an ABAP system` from the Command Palette to unlock all tools.
+
 This is a high-level summary. See the left navigation for full feature pages.
 
 | Area | Capabilities |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -2,6 +2,8 @@
 
 > **Prerequisites:** Complete the [Installation Steps](getting-started/installation.md) first. You need VS Code with ABAP FS installed and configured with at least one SAP system connection.
 
+> **Note:** ABAP FS has 40+ AI tools. When using GitHub Copilot in VS Code, all tools are available natively once a SAP system is connected — no MCP server needed. The MCP server is only for external AI clients.
+
 ## What Is This and Why Would You Need It?
 
 **MCP (Model Context Protocol)** is an open standard that lets AI tools call external services. ABAP FS exposes its 39 SAP tools (search, read code, run tests, query data, etc.) via a local MCP server so that AI assistants outside of VS Code can use them.
@@ -24,27 +26,35 @@ Also applies to AI agents plugins for vscode like Cline/Continue/Roo code/... un
 
 ## Setup
 
-### 1. Enable the MCP Server
+### 1. Start the MCP Server
 
-Open VS Code Settings (`Ctrl+,`) and search for `abapfs.mcpServer`. Set:
+Press `Ctrl+Shift+P` and run: **ABAP FS: Start MCP Server**
+
+That's it — the server starts immediately on the default port (4847). A notification confirms it's running.
+
+> If you have GitHub Copilot installed, ABAP FS will ask whether you actually need the MCP server (Copilot already has native access to all tools). You can choose to start anyway or cancel.
+
+### 2. (Optional) Change Port or Add API Key
+
+Running the command automatically enables `autoStart` — VS Code will start the MCP server on every launch going forward. You don't need to touch settings for that.
+
+If you need to change the port or secure the server with an API key:
+
+Open VS Code Settings (`Ctrl+,`) and search for `abapfs.mcpServer`:
 
 | Setting                      | Description                                                                 |
 | ---------------------------- | --------------------------------------------------------------------------- |
-| `abapfs.mcpServer.autoStart` | Set to `true` to start automatically on VS Code launch                      |
 | `abapfs.mcpServer.port`      | Default `4847` — change if there's a port conflict                          |
 | `abapfs.mcpServer.apiKey`    | Optional. Recommended on shared machines to prevent unauthorized SAP access |
 
-Or add directly to your `settings.json` (`Ctrl+Shift+P` → "Open User Settings (JSON)"):
+Or add directly to your `settings.json`:
 
 ```json
 {
-  "abapfs.mcpServer.autoStart": true,
   "abapfs.mcpServer.port": 4847,
   "abapfs.mcpServer.apiKey": "your-secret-key"
 }
 ```
-
-Reload VS Code after changing settings. A notification confirms the server is running: _"MCP Server running on port 4847"_
 
 ### 2. Connect to Your SAP System
 
@@ -99,7 +109,7 @@ In your AI tool, ask something SAP-related, for example:
 
 ## Available Tools
 
-All 39 ABAP FS tools are exposed, including:
+All 40 ABAP FS tools are exposed, including:
 
 | Tool                        | What It Does                       |
 | --------------------------- | ---------------------------------- |
@@ -126,9 +136,10 @@ All 39 ABAP FS tools are exposed, including:
 
 ### Server not starting
 
-- Confirm `abapfs.mcpServer.autoStart` is `true` in settings
+- Run `ABAP FS: Start MCP Server` from the Command Palette to start it manually
+- If you previously chose "Disable MCP", re-run the command — it will start and re-enable auto-start
 - Open the VS Code Output panel (`Ctrl+Shift+U`) and select "ABAP FS" for error messages
-- Try a different port if 4847 is already in use
+- Try a different port if 4847 is already in use (`abapfs.mcpServer.port` in settings)
 
 ### Tools not working
 

--- a/package.json
+++ b/package.json
@@ -427,7 +427,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_abap_object_lines",
@@ -514,7 +515,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "search_abap_object_lines",
@@ -565,7 +567,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_abap_object_info",
@@ -638,7 +641,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_batch_lines",
@@ -689,7 +693,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_object_by_uri",
@@ -728,7 +733,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "create_object_programmatically",
@@ -868,7 +874,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_abap_object_url",
@@ -902,7 +909,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_abap_object_workspace_uri",
@@ -936,7 +944,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "create_mermaid_diagram",
@@ -992,7 +1001,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "validate_mermaid_syntax",
@@ -1021,7 +1031,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_mermaid_documentation",
@@ -1066,7 +1077,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "detect_mermaid_diagram_type",
@@ -1090,7 +1102,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "create_test_documentation",
@@ -1166,7 +1179,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "execute_data_query",
@@ -1335,7 +1349,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_abap_sql_syntax",
@@ -1351,7 +1366,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "run_atc_analysis",
@@ -1410,7 +1426,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_atc_decorations",
@@ -1431,7 +1448,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "manage_text_elements",
@@ -1510,7 +1528,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "open_object",
@@ -1543,7 +1562,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "run_unit_tests",
@@ -1572,7 +1592,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "create_test_include",
@@ -1601,7 +1622,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "manage_transport_requests",
@@ -1651,7 +1673,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "abap_debug_session",
@@ -1694,7 +1717,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "abap_debug_breakpoint",
@@ -1744,7 +1768,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "abap_debug_step",
@@ -1789,7 +1814,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "abap_debug_variable",
@@ -1868,7 +1894,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "abap_debug_stack",
@@ -1897,7 +1924,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "abap_debug_status",
@@ -1921,7 +1949,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "analyze_abap_dumps",
@@ -1966,7 +1995,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "analyze_abap_traces",
@@ -2014,7 +2044,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "find_where_used",
@@ -2092,7 +2123,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_sap_system_info",
@@ -2121,7 +2153,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_connected_systems",
@@ -2138,7 +2171,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "get_version_history",
@@ -2198,7 +2232,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "manage_subagents",
@@ -2251,7 +2286,8 @@
           "required": [
             "action"
           ]
-        }
+        },
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "abap_fs_documentation",
@@ -2439,7 +2475,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "adt_discovery_export",
@@ -2463,7 +2500,8 @@
         },
         "tags": [
           "abap-fs"
-        ]
+        ],
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
         "name": "abap_activate",
@@ -2482,7 +2520,8 @@
           "required": [
             "url"
           ]
-        }
+        },
+        "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       }
     ],
     "commands": [
@@ -2599,6 +2638,11 @@
       {
         "command": "abapfs.connectionManager",
         "title": "Connection Manager",
+        "category": "ABAP FS"
+      },
+      {
+        "command": "abapfs.startMcpServer",
+        "title": "Start MCP Server",
         "category": "ABAP FS"
       },
       {
@@ -3016,6 +3060,11 @@
         "category": "ABAP FS"
       },
       {
+        "command": "abapfs.changePassword",
+        "title": "Change Connection Password",
+        "category": "ABAP FS"
+      },
+      {
         "command": "abapfs.atcChecks",
         "title": "Run ABAP Test cockpit",
         "category": "ABAP FS",
@@ -3241,6 +3290,9 @@
           "command": "abapfs.connect"
         },
         {
+          "command": "abapfs.startMcpServer"
+        },
+        {
           "command": "abapfs.rapGenFromEditor"
         },
         {
@@ -3277,6 +3329,10 @@
         },
         {
           "command": "abapfs.clearPassword",
+          "when": "abapfs:extensionActive"
+        },
+        {
+          "command": "abapfs.changePassword",
           "when": "abapfs:extensionActive"
         },
         {


### PR DESCRIPTION
This PR brings below improvements:
1.	Removed v2 upgrade notification popup — only a blinking status bar item remains, persists across window reloads until dismissed
2.	Renamed "Add Application Server" → "Add SAP System" in Connection Manager UI and docs to be more clear
3.	Virtual tools fix: changed to non-modal notification, deferred until first SAP connection, only runs when AI models are available in Github Copilot
4.	LM tools hidden via when clause when no SAP system is connected (saves tokens); documentation tool always available
5.	MCP server: new "Start MCP Server" command (no restart needed), sets autostart setting automatically and shows a one-time quick pick when AI models are detected in Github Copilot to mention MCP is not needed for Copilot, user can choose to enable MCP anyway
6.	Connect command: user-friendly error handling — missing/invalid config opens Connection Manager automatically, 401/503 show clear messages
7.	FsProvider: HTTP errors (401/403/503) mapped to proper FileSystemError with actionable messages (proxy, SICF, credentials)
8.	ADT folders are now added to end of workspace instead of beginning - preserves user's folder order and keeps existing local folders on top so agents files for example will be stored in local workspace rather than inside ADT folders. 
9.	New "Change Connection Password" command — update stored credentials without forgetting and reconnecting. Forget connection password command is kept so you can also clear password when needed.