### PR TITLE
MCP write and syntax check tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ bookmarks.json
 .github/agents/
 .github/agents_disabled/
 .github/skills/
+.github/
 .vscode/
 # Webpack cache directories
 client/node_modules/.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ bookmarks.json
 .github/agents/
 .github/agents_disabled/
 .github/skills/
-.github/
 .vscode/
 # Webpack cache directories
 client/node_modules/.cache/

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ For detailed setup, see the [Installation Guide](https://marcellourbani.github.i
 ### 📚 MCP Server (For Non-GitHub Copilot Users)
 
 - **Works with Cursor, Claude Code, Windsurf, Claude Desktop** - Any MCP-compatible AI tool
-- **All 40 tools exposed** - Read code, search, run tests, analyze dumps, etc.
-- **Read-only limitation** - MCP tools can read but cannot edit ABAP files directly (apply changes manually in VS Code)
+- **All 40+ tools exposed** - Read code, search, edit code, run tests, analyze dumps, etc.
+- **Write support** - MCP clients can edit ABAP source code directly via `replace_string_in_abap_object` and verify with `get_abap_diagnostics`
 - **VS Code as host** - VS Code stays open as the SAP connection bridge
 - See [MCP Server Documentation](https://marcellourbani.github.io/vscode_abap_remote_fs/mcp-server/) for setup and full limitations
 

--- a/client/src/services/lm-tools/mcpGetDiagnosticsTool.ts
+++ b/client/src/services/lm-tools/mcpGetDiagnosticsTool.ts
@@ -1,0 +1,122 @@
+
+/**
+ * MCP Get Diagnostics Tool
+ *
+ * MCP-only tool that returns syntax errors/warnings/info for a given ABAP file URI.
+ * VS Code Copilot uses its built-in get_errors tool; this provides the same for MCP clients.
+ */
+
+import * as vscode from "vscode"
+import { triggerSyntaxCheck } from "../../langClient"
+
+// ============================================================================
+// INTERFACE
+// ============================================================================
+
+export interface IMcpGetDiagnosticsParams {
+  /** The full workspace URI of the ABAP source file (e.g. 'adt://dev100/path/to/file.prog.abap'). */
+  fileUri: string
+}
+
+// ============================================================================
+// CORE LOGIC
+// ============================================================================
+
+/**
+ * Get diagnostics (errors, warnings, info) for a given file URI.
+ * Opens the document first to ensure diagnostics are computed, then waits briefly.
+ */
+export async function getDiagnosticsForUri(fileUri: string): Promise<string> {
+  const uri = vscode.Uri.parse(fileUri)
+
+  if (uri.scheme !== "adt") {
+    throw new Error(
+      `Invalid URI scheme '${uri.scheme}'. Expected 'adt://' URI. ` +
+        "Use the get_abap_object_workspace_uri tool to get the correct URI."
+    )
+  }
+
+  // Check if the file is already open in an editor tab
+  const alreadyOpen = vscode.window.tabGroups.all.some(group =>
+    group.tabs.some(tab => {
+      if (tab.input instanceof vscode.TabInputText) {
+        return tab.input.uri.toString() === uri.toString()
+      }
+      return false
+    })
+  )
+
+  let diagnostics: vscode.Diagnostic[]
+
+  if (alreadyOpen) {
+    // File is already open - language server already knows about it
+    await triggerSyntaxCheck(uri.toString())
+    await new Promise(resolve => setTimeout(resolve, 1000))
+    diagnostics = vscode.languages.getDiagnostics(uri)
+  } else {
+    // File not open - must show it to trigger didOpen in language server
+    try {
+      const doc = await vscode.workspace.openTextDocument(uri)
+      await vscode.window.showTextDocument(doc, { preserveFocus: true, preview: true })
+    } catch {
+      throw new Error(`File not found: ${fileUri}`)
+    }
+
+    // Wait for language server didOpen + syntax check (server has 500ms delay on didOpen)
+    await new Promise(resolve => setTimeout(resolve, 2000))
+
+    // Also explicitly trigger in case the didOpen race was lost
+    await triggerSyntaxCheck(uri.toString())
+    await new Promise(resolve => setTimeout(resolve, 1000))
+
+    diagnostics = vscode.languages.getDiagnostics(uri)
+
+    // Close the tab we opened to avoid cluttering the editor
+    const tabToClose = vscode.window.tabGroups.all
+      .flatMap(group => group.tabs)
+      .find(tab => {
+        if (tab.input instanceof vscode.TabInputText) {
+          return tab.input.uri.toString() === uri.toString()
+        }
+        return false
+      })
+    if (tabToClose) {
+      await vscode.window.tabGroups.close(tabToClose)
+    }
+  }
+
+  if (diagnostics.length === 0) {
+    return `No diagnostics found for ${fileUri}. The file has no syntax errors or warnings.`
+  }
+
+  const severityLabel = (s: vscode.DiagnosticSeverity): string => {
+    switch (s) {
+      case vscode.DiagnosticSeverity.Error:
+        return "ERROR"
+      case vscode.DiagnosticSeverity.Warning:
+        return "WARNING"
+      case vscode.DiagnosticSeverity.Information:
+        return "INFO"
+      case vscode.DiagnosticSeverity.Hint:
+        return "HINT"
+      default:
+        return "UNKNOWN"
+    }
+  }
+
+  const lines = diagnostics.map(d => {
+    const range = `Line ${d.range.start.line + 1}, Col ${d.range.start.character + 1}`
+    const severity = severityLabel(d.severity)
+    const source = d.source ? ` [${d.source}]` : ""
+    return `${severity} ${range}${source}: ${d.message}`
+  })
+
+  const errorCount = diagnostics.filter(d => d.severity === vscode.DiagnosticSeverity.Error).length
+  const warningCount = diagnostics.filter(
+    d => d.severity === vscode.DiagnosticSeverity.Warning
+  ).length
+
+  const summary = `Found ${diagnostics.length} diagnostic(s): ${errorCount} error(s), ${warningCount} warning(s)\n`
+
+  return summary + "\n" + lines.join("\n")
+}

--- a/client/src/services/lm-tools/mcpReplaceStringTool.ts
+++ b/client/src/services/lm-tools/mcpReplaceStringTool.ts
@@ -1,0 +1,130 @@
+
+/**
+ * MCP Replace String in ABAP Object Tool
+ *
+ * This tool is MCP-only (not a VS Code LM tool). It enables external AI clients
+ * (Cursor, Claude Code, Cline, etc.) to edit ABAP source code by performing
+ * find-and-replace operations on files identified by their workspace URI.
+ *
+ * When VS Code Copilot edits ABAP files, it uses its built-in replace_string_in_file
+ * tool which operates on the adt:// filesystem. External MCP clients don't have
+ * access to those built-in tools, so this tool provides equivalent functionality.
+ *
+ * Flow:
+ * 1. AI gets workspace URI via get_abap_object_workspace_uri tool
+ * 2. AI reads current content via get_abap_object_lines
+ * 3. AI calls this tool with the URI, oldString, and newString
+ * 4. This tool reads the file, validates the match, replaces, and writes back
+ * 5. The adt:// filesystem provider handles locking, transport selection, and SAP sync
+ */
+
+import * as vscode from "vscode"
+
+// ============================================================================
+// INTERFACE
+// ============================================================================
+
+export interface IMcpReplaceStringParams {
+  /** The full workspace URI of the ABAP source file (e.g. 'adt://dev100/path/to/file.prog.abap').
+   * Get this URI using the get_abap_object_workspace_uri tool. */
+  fileUri: string
+  /** The exact literal text to find and replace. Must match exactly one occurrence in the file.
+   * Include enough context (3-5 surrounding lines) to ensure uniqueness. Cannot be empty. */
+  oldString: string
+  /** The replacement text. The resulting code must be syntactically valid ABAP. */
+  newString: string
+}
+
+// ============================================================================
+// CORE LOGIC
+// ============================================================================
+
+/**
+ * Perform a single find-and-replace on file content.
+ * Returns the updated content or throws if match is not exactly 1.
+ */
+export function findAndReplace(content: string, oldString: string, newString: string): string {
+  if (!oldString) {
+    throw new Error("oldString cannot be empty. To create new ABAP objects, use the create_object_programmatically tool followed by editing via this tool.")
+  }
+
+  if (oldString === newString) {
+    throw new Error("oldString and newString are identical. No change would be made.")
+  }
+
+  // Count occurrences
+  let count = 0
+  let searchIdx = 0
+  while (true) {
+    const idx = content.indexOf(oldString, searchIdx)
+    if (idx === -1) break
+    count++
+    searchIdx = idx + oldString.length
+  }
+
+  if (count === 0) {
+    // Try with normalized line endings
+    const normalizedContent = content.replace(/\r\n/g, "\n")
+    const normalizedOld = oldString.replace(/\r\n/g, "\n")
+    if (normalizedContent.includes(normalizedOld)) {
+      // Match found after EOL normalization - do the replacement on original content
+      const normalizedNew = newString.replace(/\r\n/g, "\n")
+      const updated = normalizedContent.replace(normalizedOld, normalizedNew)
+      // Restore original EOL style if content had \r\n
+      if (content.includes("\r\n")) {
+        return updated.replace(/(?<!\r)\n/g, "\r\n")
+      }
+      return updated
+    }
+    throw new Error(
+      "Could not find the specified oldString in the file. " +
+      "Make sure the text matches exactly (including whitespace and indentation). " +
+      "Use get_abap_object_lines or search_abap_object_lines to read the current file content first."
+    )
+  }
+
+  if (count > 1) {
+    throw new Error(
+      `Found ${count} occurrences of oldString. It must match exactly one location. ` +
+      "Include more surrounding context lines to make the match unique."
+    )
+  }
+
+  // Exactly one match - do the replacement
+  return content.replace(oldString, newString)
+}
+
+/**
+ * Execute the replace operation against the VS Code filesystem.
+ * This goes through the adt:// filesystem provider which handles
+ * locking, transport selection, and syncing to SAP.
+ */
+export async function executeReplace(
+  fileUri: string,
+  oldString: string,
+  newString: string
+): Promise<string> {
+  const uri = vscode.Uri.parse(fileUri)
+
+  // Validate URI scheme
+  if (uri.scheme !== "adt") {
+    throw new Error(
+      `Invalid URI scheme '${uri.scheme}'. Expected 'adt://' URI. ` +
+      "Use the get_abap_object_workspace_uri tool to get the correct URI."
+    )
+  }
+
+  // Read current file content
+  const contentBytes = await vscode.workspace.fs.readFile(uri)
+  const currentContent = Buffer.from(contentBytes).toString("utf8")
+
+  // Perform the replacement
+  const updatedContent = findAndReplace(currentContent, oldString, newString)
+
+  // Write back through the filesystem provider (handles lock/transport/sync)
+  // IMPORTANT: Must use Buffer.from() not TextEncoder - the FsProvider calls
+  // content.toString() which only decodes UTF-8 correctly on Buffer, not Uint8Array
+  await vscode.workspace.fs.writeFile(uri, Buffer.from(updatedContent, "utf8"))
+
+  return updatedContent
+}

--- a/client/src/services/lm-tools/mcpReplaceStringTool.ts
+++ b/client/src/services/lm-tools/mcpReplaceStringTool.ts
@@ -45,7 +45,16 @@ export interface IMcpReplaceStringParams {
  */
 export function findAndReplace(content: string, oldString: string, newString: string): string {
   if (!oldString) {
-    throw new Error("oldString cannot be empty. To create new ABAP objects, use the create_object_programmatically tool followed by editing via this tool.")
+    // Empty oldString is only allowed when the current file is completely blank
+    // (e.g. a freshly created ABAP object with no source yet).
+    if (content.length === 0) {
+      return newString
+    }
+    throw new Error(
+      "oldString can only be empty when the file is currently completely blank. " +
+      "The file has existing content, so oldString is mandatory. " +
+      "Read the current content with get_abap_object_lines first and include the exact text to replace."
+    )
   }
 
   if (oldString === newString) {

--- a/client/src/services/mcpServer.ts
+++ b/client/src/services/mcpServer.ts
@@ -24,6 +24,8 @@ import { z } from "zod"
 import { log } from "../lib"
 import { toolRegistry } from "./lm-tools/toolRegistry"
 import { funWindow as window } from "./funMessenger"
+import { executeReplace } from "./lm-tools/mcpReplaceStringTool"
+import { getDiagnosticsForUri } from "./lm-tools/mcpGetDiagnosticsTool"
 
 // ============================================================================
 // TYPES
@@ -307,6 +309,125 @@ function createMcpServer(): McpServer {
       }
     )
   }
+
+  // ============================================================================
+  // MCP-ONLY TOOLS (not available as VS Code LM tools)
+  // ============================================================================
+
+  // Replace String in ABAP Object - enables MCP clients to edit ABAP source code
+  server.registerTool(
+    "replace_string_in_abap_object",
+    {
+      title: "Replace String In ABAP Object",
+      description:
+        "Edit ABAP source code by replacing a specific text string with new text. " +
+        "This tool performs a find-and-replace operation on an ABAP source file identified by its workspace URI. " +
+        "The oldString must match EXACTLY ONE occurrence in the file - include 3-5 lines of surrounding context to ensure uniqueness. " +
+        "The file is automatically locked, saved to SAP, and unlocked.\n\n" +
+        "Prerequisites: First call get_abap_object_workspace_uri to get the fileUri. " +
+        "Then call get_abap_object_lines or search_abap_object_lines to read current content before editing.\n\n" +
+        "IMPORTANT: oldString cannot be empty. To create new objects, use create_object_programmatically first, then edit with this tool.\n\n" +
+        "After editing, call get_abap_diagnostics with the same fileUri to verify the code has no syntax errors.",
+      inputSchema: {
+        fileUri: z.string().describe(
+          "The full workspace URI of the ABAP source file." +
+          "Get this using the get_abap_object_workspace_uri tool."
+        ),
+        oldString: z.string().min(1).describe(
+          "The exact literal text to find and replace. Must match exactly one occurrence in the file. " +
+          "Include at least 3-5 lines of surrounding context to ensure uniqueness. " +
+          "Must match whitespace and indentation precisely."
+        ),
+        newString: z.string().describe(
+          "The replacement text. Ensure the resulting code is syntactically valid ABAP."
+        )
+      }
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        const fileUri = args.fileUri as string
+        const oldString = args.oldString as string
+        const newString = args.newString as string
+
+        if (!fileUri) {
+          throw new Error("fileUri is required")
+        }
+        if (!oldString) {
+          throw new Error("oldString is required and cannot be empty")
+        }
+        if (newString === undefined || newString === null) {
+          throw new Error("newString is required (use empty string to delete text)")
+        }
+
+        await executeReplace(fileUri, oldString, newString)
+
+        const oldLineCount = oldString.split("\n").length
+        const newLineCount = newString.split("\n").length
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                `✅ Successfully replaced ${oldLineCount} line(s) with ${newLineCount} line(s) in ${fileUri}\n\n` +
+                `The file has been saved and synced to SAP.`
+            }
+          ]
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `❌ Error: ${errorMessage}`
+            }
+          ],
+          isError: true
+        }
+      }
+    }
+  )
+
+  // Get Diagnostics - returns syntax errors/warnings for a given ABAP file
+  server.registerTool(
+    "get_abap_diagnostics",
+    {
+      title: "Get ABAP Diagnostics",
+      description:
+        "Get syntax errors, warnings, and other diagnostics for an ABAP source file. " +
+        "Returns all problems detected by the ABAP language server (syntax check results). " +
+        "Use this after editing code with replace_string_in_abap_object to verify there are no syntax errors. " +
+        "Always call this after making code changes.\n\n" +
+        "Prerequisite: Use get_abap_object_workspace_uri to get the fileUri.",
+      inputSchema: {
+        fileUri: z.string().describe(
+          "The full workspace URI of the ABAP source file. " +
+          "Get this using the get_abap_object_workspace_uri tool."
+        )
+      }
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        const fileUri = args.fileUri as string
+        if (!fileUri) {
+          throw new Error("fileUri is required")
+        }
+
+        const result = await getDiagnosticsForUri(fileUri)
+
+        return {
+          content: [{ type: "text" as const, text: result }]
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        return {
+          content: [{ type: "text" as const, text: `❌ Error: ${errorMessage}` }],
+          isError: true
+        }
+      }
+    }
+  )
 
   return server
 }

--- a/client/src/services/mcpServer.ts
+++ b/client/src/services/mcpServer.ts
@@ -326,17 +326,18 @@ function createMcpServer(): McpServer {
         "The file is automatically locked, saved to SAP, and unlocked.\n\n" +
         "Prerequisites: First call get_abap_object_workspace_uri to get the fileUri. " +
         "Then call get_abap_object_lines or search_abap_object_lines to read current content before editing.\n\n" +
-        "IMPORTANT: oldString cannot be empty. To create new objects, use create_object_programmatically first, then edit with this tool.\n\n" +
+        "IMPORTANT: oldString is mandatory whenever the file has any content. An empty oldString is accepted ONLY when the file is currently completely blank (e.g. a freshly created ABAP object with no source yet) - in that case the entire newString becomes the file content.\n\n" +
         "After editing, call get_abap_diagnostics with the same fileUri to verify the code has no syntax errors.",
       inputSchema: {
         fileUri: z.string().describe(
           "The full workspace URI of the ABAP source file." +
           "Get this using the get_abap_object_workspace_uri tool."
         ),
-        oldString: z.string().min(1).describe(
+        oldString: z.string().describe(
           "The exact literal text to find and replace. Must match exactly one occurrence in the file. " +
           "Include at least 3-5 lines of surrounding context to ensure uniqueness. " +
-          "Must match whitespace and indentation precisely."
+          "Must match whitespace and indentation precisely. " +
+          "May be an empty string ONLY if the target file is currently completely blank; otherwise it is mandatory."
         ),
         newString: z.string().describe(
           "The replacement text. Ensure the resulting code is syntactically valid ABAP."
@@ -352,12 +353,12 @@ function createMcpServer(): McpServer {
         if (!fileUri) {
           throw new Error("fileUri is required")
         }
-        if (!oldString) {
-          throw new Error("oldString is required and cannot be empty")
-        }
         if (newString === undefined || newString === null) {
           throw new Error("newString is required (use empty string to delete text)")
         }
+        // Note: empty oldString is allowed only when the file is blank.
+        // That check happens inside executeReplace/findAndReplace once the
+        // current file content is known.
 
         await executeReplace(fileUri, oldString, newString)
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -6,7 +6,7 @@
 
 **MCP (Model Context Protocol)** is an open standard that lets AI tools call external services. ABAP FS exposes its 39 SAP tools (search, read code, run tests, query data, etc.) via a local MCP server so that AI assistants outside of VS Code can use them.
 
-> **Warning:** MCP access is read-only. See [Limitations](#limitations) for details.
+> **Note:** MCP now supports both reading and writing ABAP code. See [Write Support](#write-support) for details.
 
 **Use this if** you work with AI tools like Cursor, Claude Desktop, Claude Code, or Windsurf and want them to have the same SAP access that GitHub Copilot has inside VS Code.
 Also applies to AI agents plugins for vscode like Cline/Continue/Roo code/... unless they support the [virtual filesystem API](https://code.visualstudio.com/api/extension-guides/virtual-workspaces) AFAIK only copilot does at the moment
@@ -99,7 +99,7 @@ In your AI tool, ask something SAP-related, for example:
 
 ## Available Tools
 
-All 39 ABAP FS tools are exposed, including:
+All 40 ABAP FS tools are exposed, including:
 
 | Tool                        | What It Does                       |
 | --------------------------- | ---------------------------------- |
@@ -111,14 +111,26 @@ All 39 ABAP FS tools are exposed, including:
 | `execute_data_query`        | Run SQL queries against SAP tables |
 | `manage_transport_requests` | Read transport data                |
 | `abap_activate`             | Activate ABAP objects              |
+| `replace_string_in_abap_object` | Edit ABAP source code (find & replace) |
+| `get_abap_diagnostics`      | Get syntax errors/warnings for a file  |
+
+## Write Support
+
+MCP clients can now edit ABAP source code directly. The workflow:
+
+1. **Get the file URI** — call `get_abap_object_workspace_uri` with object name/type/connection
+2. **Read current code** — call `get_abap_object_lines` or `search_abap_object_lines`
+3. **Edit** — call `replace_string_in_abap_object` with the URI, old text, and new text
+4. **Verify** — call `get_abap_diagnostics` with the same URI to check for syntax errors
+
+Edits are immediately synced to SAP (ABAP FS handles locking, saving, and unlocking automatically). There is no keep/undo UI — changes are applied directly.
+
 
 ## Limitations
 
 - **VS Code must stay open** — the server runs inside VS Code
 - **Active SAP connection required** — tools need a connected system
-- **Read-oriented** — external AI tools cannot write to the `adt://` virtual filesystem; the AI can suggest edits but you must apply them manually in VS Code
 - **Webview outputs appear in VS Code** — results from tools like data queries or Mermaid diagrams open as VS Code panels, not in the external tool
-- **No ABAP syntax checking** — ABAP code is treated as plain text in external tools
 - **No navigation features** — Go to Definition, Find References, and hover documentation require the VS Code ABAP FS integration
 - **Debugging requires VS Code** — the ABAP debugger is VS Code-specific
 


### PR DESCRIPTION
This PR adds 2 new MCP-only tools - replace_string_in_abap_object for code editing and get_abap_diagnostics to get syntax errors.