### PR TITLE
feat(mcp): add update_abap_source tool for external AI clients

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -45,6 +45,7 @@ import { SapSystemValidator } from "./services/sapSystemValidator"
 import { listAdtFeedsCommand } from "./commands/listAdtFeeds"
 import { validateSubagentsOnStartup } from "./services/lm-tools/subagentConfigTool"
 import { initializeMcpServer } from "./services/mcpServer"
+import { registerUpdateAbapSourceTool } from "./services/mcp-only-tools/updateAbapSourceTool"
 import { registerChatTools } from "./adt/ai/tools"
 import { initializeEnhancementDecorations } from "./views/enhancementDecorations"
 import { initializeBlameGutter } from "./views/blameGutter"
@@ -144,6 +145,11 @@ export async function activate(ctx: ExtensionContext): Promise<AbapFsApi> {
 
     // Register Language Model Tools for proper AI integration (includes Mermaid tools)
     await registerAllTools(context)
+
+    // Register MCP-only tools — visible only to external MCP clients, NOT to
+    // Copilot. Must run before initializeMcpServer so the tools are in the
+    // registry when the server snapshots it.
+    registerUpdateAbapSourceTool()
 
     // Register ABAP Cleaner feature
     registerCleanerCommands(context)

--- a/client/src/services/mcp-only-tools/mcpOnlyRegistry.ts
+++ b/client/src/services/mcp-only-tools/mcpOnlyRegistry.ts
@@ -1,0 +1,48 @@
+/**
+ * MCP-only tool registry.
+ *
+ * Tools registered here are exposed ONLY through the MCP server (for external
+ * AI clients such as Claude Desktop, Cursor, headless agents). They are
+ * intentionally NOT registered with `vscode.lm.registerTool()` and NOT declared
+ * in `package.json` `contributes.languageModelTools`, so they will not appear
+ * in `vscode.lm.tools` and Copilot Chat (in agent mode) will not discover or
+ * invoke them. This keeps the existing Copilot workflow — which relies on the
+ * built-in file edit tool plus the `adt://` FileSystemProvider — completely
+ * untouched.
+ *
+ * Use registerMcpOnlyTool() to add a new tool. The MCP server iterates this
+ * registry alongside the regular `abap-fs`-tagged tools when building its
+ * tool list.
+ */
+
+export interface McpOnlyTool {
+  /** MCP tool name (snake_case). */
+  name: string
+  /** One-paragraph description sent to the MCP client. */
+  description: string
+  /**
+   * JSON Schema for the input. The MCP server converts this to a Zod schema
+   * via the same jsonSchemaToZod helper used for the regular LM tools.
+   */
+  inputSchema: Record<string, unknown>
+  /**
+   * Implementation. Returns the markdown text shown to the agent. Throw to
+   * surface an error (the MCP server will wrap it as `{ isError: true }`).
+   */
+  invoke: (args: Record<string, unknown>) => Promise<string>
+}
+
+const registry = new Map<string, McpOnlyTool>()
+
+export function registerMcpOnlyTool(tool: McpOnlyTool): void {
+  registry.set(tool.name, tool)
+}
+
+export function getMcpOnlyTools(): McpOnlyTool[] {
+  return Array.from(registry.values())
+}
+
+/** Test-only: clear the registry between unit tests. */
+export function _resetMcpOnlyRegistryForTests(): void {
+  registry.clear()
+}

--- a/client/src/services/mcp-only-tools/updateAbapSourceTool.test.ts
+++ b/client/src/services/mcp-only-tools/updateAbapSourceTool.test.ts
@@ -1,0 +1,202 @@
+jest.mock(
+  "vscode",
+  () => ({
+    Uri: {
+      parse: jest.fn((s: string) => {
+        // Minimal stub: accept adt://authority/path[/...] ; reject anything that doesn't
+        // look like a URI to mimic vscode.Uri.parse(strict) behavior.
+        const m = /^([a-zA-Z][a-zA-Z0-9+.-]*):\/\/([^/]*)(\/.*)?$/.exec(s)
+        if (!m) {
+          throw new Error(`invalid uri: ${s}`)
+        }
+        const [, scheme, authority, path] = m
+        return {
+          scheme,
+          authority,
+          path: path || "",
+          toString: () => s
+        }
+      })
+    },
+    workspace: {
+      fs: {
+        writeFile: jest.fn()
+      },
+      textDocuments: [] as any[]
+    }
+  }),
+  { virtual: true }
+)
+
+jest.mock("abapfs", () => ({
+  isAbapFile: jest.fn()
+}))
+
+jest.mock("../../adt/conections", () => ({
+  getOrCreateRoot: jest.fn()
+}))
+
+jest.mock("../../adt/operations/AdtObjectActivator", () => ({
+  AdtObjectActivator: {
+    get: jest.fn()
+  }
+}))
+
+jest.mock("../telemetry", () => ({ logTelemetry: jest.fn() }))
+
+import * as vscode from "vscode"
+import { isAbapFile } from "abapfs"
+import { getOrCreateRoot } from "../../adt/conections"
+import { AdtObjectActivator } from "../../adt/operations/AdtObjectActivator"
+import { logTelemetry } from "../telemetry"
+import { _internal, registerUpdateAbapSourceTool } from "./updateAbapSourceTool"
+import {
+  getMcpOnlyTools,
+  _resetMcpOnlyRegistryForTests
+} from "./mcpOnlyRegistry"
+
+const URI = "adt://dev100/sap/bc/adt/programs/programs/zfoo/source/main"
+
+function makeNode(name = "ZFOO") {
+  return { object: { name } }
+}
+
+function makeRoot(node: any) {
+  return { getNodeAsync: jest.fn().mockResolvedValue(node) }
+}
+
+function makeActivator(result: { ok: boolean; summary?: string; details?: string }) {
+  return { activate: jest.fn().mockResolvedValue(result) }
+}
+
+describe("update_abap_source MCP-only tool", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(vscode.workspace.textDocuments as any) = []
+    ;(isAbapFile as unknown as jest.Mock).mockReturnValue(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Validation / error paths
+  // ---------------------------------------------------------------------------
+
+  it("throws when workspaceUri is missing", async () => {
+    await expect(_internal.invoke({ source: "" } as any)).rejects.toThrow(
+      /workspaceUri is required/
+    )
+  })
+
+  it("throws when source is missing", async () => {
+    await expect(_internal.invoke({ workspaceUri: URI } as any)).rejects.toThrow(
+      /source is required/
+    )
+  })
+
+  it("throws when scheme is not adt://", async () => {
+    await expect(
+      _internal.invoke({ workspaceUri: "file:///tmp/foo", source: "" })
+    ).rejects.toThrow(/must use the adt:\/\/ scheme/)
+  })
+
+  it("throws when the node is not an AbapFile", async () => {
+    ;(getOrCreateRoot as jest.Mock).mockResolvedValue(makeRoot(makeNode()))
+    ;(isAbapFile as unknown as jest.Mock).mockReturnValue(false)
+
+    await expect(_internal.invoke({ workspaceUri: URI, source: "" })).rejects.toThrow(
+      /Not a writable ABAP source/
+    )
+    expect(vscode.workspace.fs.writeFile).not.toHaveBeenCalled()
+  })
+
+  it("throws when an editor for the same URI has unsaved changes", async () => {
+    ;(getOrCreateRoot as jest.Mock).mockResolvedValue(makeRoot(makeNode()))
+    ;(vscode.workspace.textDocuments as any) = [
+      { uri: { toString: () => URI }, isDirty: true }
+    ]
+
+    await expect(_internal.invoke({ workspaceUri: URI, source: "" })).rejects.toThrow(
+      /unsaved changes/
+    )
+    expect(vscode.workspace.fs.writeFile).not.toHaveBeenCalled()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Success / activation-failure paths
+  // ---------------------------------------------------------------------------
+
+  it("writes through workspace.fs.writeFile and reports success when activate ok", async () => {
+    ;(getOrCreateRoot as jest.Mock).mockResolvedValue(makeRoot(makeNode("ZFOO")))
+    const activator = makeActivator({ ok: true })
+    ;(AdtObjectActivator.get as jest.Mock).mockReturnValue(activator)
+
+    const text = await _internal.invoke({ workspaceUri: URI, source: "REPORT zfoo." })
+
+    expect(vscode.workspace.fs.writeFile).toHaveBeenCalledTimes(1)
+    const [calledUri, calledBytes] = (vscode.workspace.fs.writeFile as jest.Mock).mock.calls[0]
+    expect(calledUri.toString()).toBe(URI)
+    expect(Buffer.isBuffer(calledBytes) || calledBytes instanceof Uint8Array).toBe(true)
+    expect(activator.activate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "ZFOO" }),
+      expect.objectContaining({ scheme: "adt" }),
+      false
+    )
+    expect(text).toMatch(/Updated and activated/)
+    expect(text).toMatch(/ZFOO/)
+  })
+
+  it("returns structured failure (with summary/details) when activation fails — source still saved", async () => {
+    ;(getOrCreateRoot as jest.Mock).mockResolvedValue(makeRoot(makeNode("ZFOO")))
+    const activator = makeActivator({
+      ok: false,
+      summary: "Activation failed: 1 error",
+      details: "ZFOO line 3: Expected '.', got 'BAR'"
+    })
+    ;(AdtObjectActivator.get as jest.Mock).mockReturnValue(activator)
+
+    const text = await _internal.invoke({
+      workspaceUri: URI,
+      source: "REPORT zfoo BAR"
+    })
+
+    expect(vscode.workspace.fs.writeFile).toHaveBeenCalledTimes(1)
+    expect(activator.activate).toHaveBeenCalledTimes(1)
+    expect(text).toMatch(/Source written but activation failed/)
+    expect(text).toMatch(/Activation failed: 1 error/)
+    expect(text).toMatch(/Expected '\.', got 'BAR'/)
+    expect(text).toMatch(/call `update_abap_source` again/)
+  })
+
+  it("logs telemetry with the connectionId taken from the URI authority", async () => {
+    ;(getOrCreateRoot as jest.Mock).mockResolvedValue(makeRoot(makeNode()))
+    ;(AdtObjectActivator.get as jest.Mock).mockReturnValue(makeActivator({ ok: true }))
+
+    await _internal.invoke({ workspaceUri: URI, source: "" })
+
+    expect(logTelemetry).toHaveBeenCalledWith("tool_update_abap_source_called", {
+      connectionId: "dev100"
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Registry wiring
+  // ---------------------------------------------------------------------------
+
+  describe("registry wiring", () => {
+    beforeEach(() => _resetMcpOnlyRegistryForTests())
+
+    it("registerUpdateAbapSourceTool() adds update_abap_source to the MCP-only registry", () => {
+      registerUpdateAbapSourceTool()
+      const names = getMcpOnlyTools().map(t => t.name)
+      expect(names).toContain("update_abap_source")
+    })
+
+    it("registered schema declares both required fields", () => {
+      registerUpdateAbapSourceTool()
+      const tool = getMcpOnlyTools().find(t => t.name === "update_abap_source")!
+      const schema = tool.inputSchema as any
+      expect(schema.required).toEqual(expect.arrayContaining(["workspaceUri", "source"]))
+      expect(schema.properties.workspaceUri.type).toBe("string")
+      expect(schema.properties.source.type).toBe("string")
+    })
+  })
+})

--- a/client/src/services/mcp-only-tools/updateAbapSourceTool.ts
+++ b/client/src/services/mcp-only-tools/updateAbapSourceTool.ts
@@ -1,0 +1,148 @@
+/**
+ * MCP-only tool: update_abap_source
+ *
+ * Replaces the full source code of an existing ABAP object and automatically
+ * activates it. Designed for external AI agents talking to the MCP server —
+ * NOT exposed to Copilot (it is registered in the MCP-only registry, not via
+ * vscode.lm.registerTool / package.json contributions).
+ *
+ * Flow:
+ *   1. Validate the adt:// workspace URI and resolve the AbapFile node.
+ *   2. Refuse if the user has unsaved edits to the same object in VS Code
+ *      (avoid clobbering them).
+ *   3. Write through the FileSystemProvider, which transparently handles
+ *      lock acquisition, transport-request selection (a dialog may appear
+ *      in VS Code), unlock, and relogin.
+ *   4. Activate non-interactively via AdtObjectActivator.
+ *   5. On activation failure: keep the saved source (object stays inactive),
+ *      return the structured summary/details so the agent can fix the source
+ *      and call this tool again — closing the loop without human help.
+ */
+
+import * as vscode from "vscode"
+import { isAbapFile } from "abapfs"
+import { getOrCreateRoot } from "../../adt/conections"
+import { AdtObjectActivator } from "../../adt/operations/AdtObjectActivator"
+import { logTelemetry } from "../telemetry"
+import { registerMcpOnlyTool } from "./mcpOnlyRegistry"
+
+interface IUpdateAbapSourceParams {
+  workspaceUri: string
+  source: string
+}
+
+const TOOL_NAME = "update_abap_source"
+
+const TOOL_DESCRIPTION =
+  "Replace the full source code of an EXISTING ABAP object and automatically activate it. " +
+  "Use after get_abap_object_workspace_uri to obtain the adt:// URI. " +
+  "The tool writes via the VS Code adt:// FileSystemProvider, which handles lock " +
+  "acquisition and transport-request selection (a transport dialog may appear in VS Code if " +
+  "the object is not LOCAL and not yet locked to a transport). " +
+  "If activation fails, the source is still saved and the tool returns structured syntax/check " +
+  "errors (with file/line/severity) so the agent can fix the source and call this tool again. " +
+  "Only updates existing objects — use create_object_programmatically to create new ones."
+
+const INPUT_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  required: ["workspaceUri", "source"],
+  properties: {
+    workspaceUri: {
+      type: "string",
+      description:
+        "adt:// workspace URI of the existing ABAP source file " +
+        "(e.g. adt://dev100/sap/bc/adt/programs/programs/zfoo/source/main). " +
+        "Obtain via get_abap_object_workspace_uri."
+    },
+    source: {
+      type: "string",
+      description:
+        "The complete new source code. Replaces the entire object source — read the " +
+        "current source first (get_abap_object_lines) and send back the full intended content."
+    }
+  }
+}
+
+async function invoke(args: Record<string, unknown>): Promise<string> {
+  const { workspaceUri, source } = args as unknown as IUpdateAbapSourceParams
+
+  if (typeof workspaceUri !== "string" || !workspaceUri) {
+    throw new Error("workspaceUri is required and must be a non-empty string")
+  }
+  if (typeof source !== "string") {
+    throw new Error("source is required and must be a string")
+  }
+
+  let uri: vscode.Uri
+  try {
+    uri = vscode.Uri.parse(workspaceUri, true)
+  } catch (e) {
+    throw new Error(`Invalid workspaceUri: ${String(e)}`)
+  }
+  if (uri.scheme !== "adt") {
+    throw new Error(`workspaceUri must use the adt:// scheme (got "${uri.scheme}://")`)
+  }
+
+  logTelemetry("tool_update_abap_source_called", { connectionId: uri.authority })
+
+  // Resolve the node so we can (a) check it's a writable AbapFile and
+  // (b) hand the AbapObject to the activator afterwards.
+  const root = await getOrCreateRoot(uri.authority)
+  const node = await root.getNodeAsync(uri.path)
+  if (!isAbapFile(node)) {
+    throw new Error(
+      `Not a writable ABAP source: ${workspaceUri}. ` +
+        `The URI must point at an editable source file (e.g. .../source/main).`
+    )
+  }
+
+  // If the user has the same object open with unsaved edits, refuse rather
+  // than silently overwrite their changes.
+  const dirty = vscode.workspace.textDocuments.find(
+    d => d.uri.toString() === uri.toString() && d.isDirty
+  )
+  if (dirty) {
+    throw new Error(
+      `Editor for ${workspaceUri} has unsaved changes; save or revert in VS Code before calling update_abap_source.`
+    )
+  }
+
+  // Write through the FileSystemProvider — this triggers lock + transport
+  // dialog + write + unlock + relogin, exactly the same path Copilot uses.
+  const bytes = Buffer.from(source, "utf8")
+  await vscode.workspace.fs.writeFile(uri, bytes)
+
+  // Always activate non-interactively. On failure the source remains saved;
+  // we hand the structured error back so the agent can correct and retry.
+  const activator = AdtObjectActivator.get(uri.authority)
+  const result = await activator.activate(node.object, uri, /* interactive */ false)
+
+  const objectName = node.object.name
+  if (result.ok) {
+    return (
+      `**✅ Updated and activated** ${objectName}\n` +
+      `• Workspace URI: \`${workspaceUri}\`\n` +
+      `• Source bytes: ${bytes.length}`
+    )
+  }
+
+  return (
+    `**⚠️ Source written but activation failed** for ${objectName}\n\n` +
+    `**Summary:** ${result.summary ?? "(no summary)"}\n\n` +
+    `**Details:**\n\`\`\`\n${result.details ?? "(no details)"}\n\`\`\`\n\n` +
+    `**Next step:** fix the syntax/check errors above and call \`${TOOL_NAME}\` again with the corrected full source. ` +
+    `The object is currently inactive in SAP — repeated calls overwrite the inactive version, no manual cleanup needed.`
+  )
+}
+
+export function registerUpdateAbapSourceTool(): void {
+  registerMcpOnlyTool({
+    name: TOOL_NAME,
+    description: TOOL_DESCRIPTION,
+    inputSchema: INPUT_SCHEMA,
+    invoke
+  })
+}
+
+// Exported for tests.
+export const _internal = { invoke, TOOL_NAME, TOOL_DESCRIPTION, INPUT_SCHEMA }

--- a/client/src/services/mcpServer.ts
+++ b/client/src/services/mcpServer.ts
@@ -23,6 +23,7 @@ import { randomUUID } from "crypto"
 import { z } from "zod"
 import { log } from "../lib"
 import { toolRegistry } from "./lm-tools/toolRegistry"
+import { getMcpOnlyTools } from "./mcp-only-tools/mcpOnlyRegistry"
 import { funWindow as window } from "./funMessenger"
 
 // ============================================================================
@@ -299,6 +300,49 @@ function createMcpServer(): McpServer {
               {
                 type: "text" as const,
                 text: `❌ Error invoking ${toolName}: ${errorMessage}`
+              }
+            ],
+            isError: true
+          }
+        }
+      }
+    )
+  }
+
+  // ----------------------------------------------------------------------
+  // MCP-only tools — registered via mcp-only-tools/mcpOnlyRegistry.
+  // These intentionally bypass vscode.lm.registerTool / package.json
+  // contributions, so Copilot does not see them. Only external MCP clients
+  // (Claude Desktop, Cursor, headless agents) can invoke them.
+  // ----------------------------------------------------------------------
+  for (const mcpTool of getMcpOnlyTools()) {
+    const zodSchema = jsonSchemaToZod(mcpTool.inputSchema)
+
+    server.registerTool(
+      mcpTool.name,
+      {
+        title: mcpTool.name.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase()),
+        description: mcpTool.description,
+        inputSchema: zodSchema
+      },
+      async (args: Record<string, unknown>) => {
+        try {
+          const text = await mcpTool.invoke(args)
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text
+              }
+            ]
+          }
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error)
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `❌ Error invoking ${mcpTool.name}: ${errorMessage}`
               }
             ],
             isError: true


### PR DESCRIPTION
## Problem

The extension already exposes ~40 LM tools through the MCP server (so Cursor / Claude Desktop / headless agents can use them), but none of those tools can write ABAP source code. Today's source-writing tools cover only structural creation:

- `create_object_programmatically` creates empty shells.
- `manage_text_elements` only edits text-element tables.
- `create_test_include` adds a test-include skeleton.

Copilot in agent mode does write ABAP source - but only because VS Code's built-in file-edit tool can target `adt://` URIs and the existing `FsProvider.writeFile` then transparently handles lock + transport selection + unlock + relogin. External MCP clients have no such built-in `adt://` awareness, so they currently cannot change real ABAP code through this extension.

## Solution

A new MCP tool `update_abap_source` that:

1. Takes an `adt://` workspace URI and the new full source.
2. Resolves the `AbapFile` node and refuses if the URI is not a writable ABAP source.
3. Refuses if a VS Code editor for the same URI has unsaved changes (so we don't clobber user edits).
4. Writes via `vscode.workspace.fs.writeFile`, which runs through the existing `FsProvider.writeFile` and reuses the same lock / transport-selection / unlock / relogin path Copilot already exercises - no duplication of that logic.
5. Activates non-interactively via `AdtObjectActivator.activate(obj, uri, false)`.
6. On activation failure: source stays saved (object is inactive in SAP), the structured `summary`/`details` from the activator are returned so the agent can fix the syntax/check errors and call the tool again - closing the loop without human intervention.

### Why MCP-only (and how it stays MCP-only)

Copilot's existing workflow already covers this scenario through built-in file-edit tools. Adding a new redundant LM tool would risk Copilot picking it up in agent mode and changing existing behavior. So this tool is registered in a **separate** MCP-only registry and intentionally does NOT:

- appear in `package.json` `contributes.languageModelTools`
- get passed to `vscode.lm.registerTool()`

That keeps it invisible to `vscode.lm.tools` (so Copilot won't discover it) while the MCP server happily iterates it alongside the regular `abap-fs`-tagged tools.

## Changes

| File | Purpose |
|---|---|
| `client/src/services/mcp-only-tools/mcpOnlyRegistry.ts` | New registry. `registerMcpOnlyTool(tool)` adds entries; `getMcpOnlyTools()` is what the MCP server reads. |
| `client/src/services/mcp-only-tools/updateAbapSourceTool.ts` | The tool implementation. ~150 lines, fully commented. |
| `client/src/services/mcp-only-tools/updateAbapSourceTool.test.ts` | 10 unit tests covering input validation, scheme validation, dirty-buffer protection, success path, structured-failure path, telemetry. All passing. |
| `client/src/services/mcpServer.ts` | Iterates `getMcpOnlyTools()` alongside the existing `abap-fs`-tagged tools when building the MCP server's tool list. Reuses the same `jsonSchemaToZod` helper for input schemas. |
| `client/src/extension.ts` | One call to `registerUpdateAbapSourceTool()` during activation, placed before `initializeMcpServer` so the registry is populated when the server snapshots it. |

## Tests

```
PASS src/services/mcp-only-tools/updateAbapSourceTool.test.ts
  update_abap_source MCP-only tool
    ✓ throws when workspaceUri is missing
    ✓ throws when source is missing
    ✓ throws when scheme is not adt://
    ✓ throws when the node is not an AbapFile
    ✓ throws when an editor for the same URI has unsaved changes
    ✓ writes through workspace.fs.writeFile and reports success when activate ok
    ✓ returns structured failure (with summary/details) when activation fails - source still saved
    ✓ logs telemetry with the connectionId taken from the URI authority
    registry wiring
      ✓ registerUpdateAbapSourceTool() adds update_abap_source to the MCP-only registry
      ✓ registered schema declares both required fields

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
```

`npm run webpack` passes.

## Future-proofing

The MCP-only registry is generic. Future tools that should be agent-only (without leaking into Copilot's tool list) can register via `registerMcpOnlyTool({...})` without further plumbing. If a tool later becomes safe / desirable for Copilot too, switching it over is just deleting the call to `registerMcpOnlyTool` and using the regular `abap-fs`-tagged path.

## Independence from #402

This PR is independent of #402 (perf: parallelise dual login & avoid extension-host reload). They touch different files; either can be merged first.
