### PR TITLE
Fix programmatic function module creation

### DIFF
--- a/.changeset/function-module-parent.md
+++ b/.changeset/function-module-parent.md
@@ -1,0 +1,5 @@
+---
+"vscode-abap-remote-fs": patch
+---
+
+Fix programmatic function module creation by mapping AI function module aliases to FUGR/FF and using the provided function group parent.

--- a/client/src/commands/commands.test.ts
+++ b/client/src/commands/commands.test.ts
@@ -192,7 +192,14 @@ jest.mock("../services/sapSystemInfo", () => ({
   clearSystemInfoCache: jest.fn()
 }))
 
-import { currentUri, currentAbapFile, currentEditState, openObject } from "./commands"
+import {
+  currentUri,
+  currentAbapFile,
+  currentEditState,
+  openObject,
+  AdtCommands,
+  normalizeAiCreatableObjectType
+} from "./commands"
 import { funWindow as window } from "../services/funMessenger"
 import { ADTSCHEME, getRoot } from "../adt/conections"
 import { uriAbapFile } from "../adt/operations/AdtObjectFinder"
@@ -231,6 +238,93 @@ describe("currentUri", () => {
     const uri = makeAdtUri()
     ;(mockWindow as any).activeTextEditor = { document: { uri } }
     expect(currentUri()).toBe(uri)
+  })
+})
+
+describe("normalizeAiCreatableObjectType", () => {
+  test("maps AI function module aliases to FUGR/FF", () => {
+    expect(normalizeAiCreatableObjectType("FUNC/FF" as any)).toBe("FUGR/FF")
+    expect(normalizeAiCreatableObjectType("FUNC" as any)).toBe("FUGR/FF")
+  })
+
+  test("keeps supported creatable object types unchanged", () => {
+    expect(normalizeAiCreatableObjectType("FUGR/FF" as any)).toBe("FUGR/FF")
+    expect(normalizeAiCreatableObjectType("PROG/P" as any)).toBe("PROG/P")
+  })
+})
+
+describe("createAdtObjectProgrammatically", () => {
+  test("uses FUGR/FF creatable type when AI requests FUNC/FF", async () => {
+    const { CreatableTypes } = require("abap-adt-api")
+    CreatableTypes.get = jest.fn().mockReturnValue({
+      typeId: "FUGR/FF",
+      label: "Function module",
+      maxLen: 30
+    })
+
+    const { AdtObjectCreator, PACKAGE } = require("../adt/operations/AdtObjectCreator")
+    const createdObject = {
+      type: PACKAGE,
+      name: "ZAI_TEST_FM",
+      path: "/sap/bc/adt/functions/groups/zzj_ai/fmodules/zai_test_fm",
+      loadStructure: jest.fn().mockResolvedValue(undefined)
+    }
+    AdtObjectCreator.mockImplementation(() => ({
+      createObject: jest.fn(async function (this: any) {
+        await this.guessOrSelectObjectType([])
+        return createdObject
+      })
+    }))
+
+    await AdtCommands.createAdtObjectProgrammatically(
+      "FUNC/FF",
+      "ZAI_TEST_FM",
+      "Test function module",
+      "$TMP",
+      "ZZJ_AI",
+      "dev"
+    )
+
+    expect(CreatableTypes.get).toHaveBeenCalledWith("FUGR/FF")
+  })
+
+  test("uses provided parentName as function group parent for function modules", async () => {
+    const { CreatableTypes } = require("abap-adt-api")
+    CreatableTypes.get = jest.fn().mockReturnValue({
+      typeId: "FUGR/FF",
+      label: "Function module",
+      maxLen: 30
+    })
+
+    const observedParents: Record<string, string> = {}
+    const { AdtObjectCreator, PACKAGE } = require("../adt/operations/AdtObjectCreator")
+    const createdObject = {
+      type: PACKAGE,
+      name: "ZAI_TEST_FM",
+      path: "/sap/bc/adt/functions/groups/zzj_ai/fmodules/zai_test_fm",
+      loadStructure: jest.fn().mockResolvedValue(undefined)
+    }
+    AdtObjectCreator.mockImplementation(() => ({
+      createObject: jest.fn(async function (this: any) {
+        observedParents.package = this.guessParentByType([], "DEVC/K")
+        observedParents.functionGroup = this.guessParentByType([], "FUGR/F")
+        return createdObject
+      })
+    }))
+
+    await AdtCommands.createAdtObjectProgrammatically(
+      "FUGR/FF",
+      "ZAI_TEST_FM",
+      "Test function module",
+      "$TMP",
+      "ZZJ_AI",
+      "dev"
+    )
+
+    expect(observedParents).toEqual({
+      package: "$TMP",
+      functionGroup: "ZZJ_AI"
+    })
   })
 })
 

--- a/client/src/commands/commands.ts
+++ b/client/src/commands/commands.ts
@@ -74,6 +74,13 @@ export function currentUri() {
   return uri
 }
 
+export function normalizeAiCreatableObjectType(objectType: string): CreatableTypeIds {
+  const normalized = objectType.toUpperCase()
+  // AI/LLM 往往会复用搜索工具里的 FUNC 类型；创建函数模块时 ADT 实际需要函数组子对象类型 FUGR/FF。
+  if (normalized === "FUNC" || normalized === "FUNC/FF") return "FUGR/FF" as CreatableTypeIds
+  return normalized as CreatableTypeIds
+}
+
 async function saveDirtyAdtDocuments(connectionId: string) {
   const dirtyDocuments = workspace.textDocuments.filter(
     document =>
@@ -578,7 +585,7 @@ export class AdtCommands {
    */
   @command(AbapFsCommands.createObjectProgrammatically)
   public static async createAdtObjectProgrammatically(
-    objectType: CreatableTypeIds,
+    objectType: string,
     name: string,
     description: string,
     packageName: string = "$TMP",
@@ -602,6 +609,7 @@ export class AdtCommands {
     }
   ) {
     try {
+      const normalizedObjectType = normalizeAiCreatableObjectType(objectType)
       // Use current connection or specified one
       const connId = connectionId || (await pickAdtRoot())?.uri.authority
       if (!connId) return
@@ -633,6 +641,11 @@ export class AdtCommands {
           // PACKAGE type - this is what prevents the "Select package" dialog
           return packageName
         }
+        if (type === "FUGR/F" && parentName) {
+          // Function modules are function group children; AI creation must use the provided parent group
+          // to avoid falling back to the current workspace location.
+          return parentName.toUpperCase()
+        }
         // For other types, use original logic
         const original =
           hierarchy.filter((n: any) => n.object?.type === type)?.[0]?.object?.name || ""
@@ -641,15 +654,15 @@ export class AdtCommands {
 
       // 3. Override guessOrSelectObjectType to return the specified object type
       creator["guessOrSelectObjectType"] = async (hierarchy: any[]): Promise<any> => {
-        const objType = CreatableTypes.get(objectType)
+        const objType = CreatableTypes.get(normalizedObjectType)
         if (objType) {
-          return { typeId: objectType, label: objType.label, maxLen: objType.maxLen }
+          return { typeId: normalizedObjectType, label: objType.label, maxLen: objType.maxLen }
         }
-        throw new Error(`Unknown object type: ${objectType}`)
+        throw new Error(`Unknown object type: ${normalizedObjectType}`)
       }
 
       // 4. Override getServiceOptions to use programmatic values for service bindings
-      if (objectType === "SRVB/SVB" && additionalOptions) {
+      if (normalizedObjectType === "SRVB/SVB" && additionalOptions) {
         const { serviceDefinition, bindingType, bindingCategory } = additionalOptions
         if (!serviceDefinition || !bindingType || !bindingCategory) {
           return {
@@ -657,7 +670,7 @@ export class AdtCommands {
             error: "MISSING_SERVICE_BINDING_OPTIONS",
             message: "Service bindings require additionalOptions with serviceDefinition, bindingType ('ODATA'), and bindingCategory ('0' for Web API, '1' for UI)",
             objectName: name,
-            objectType: objectType
+            objectType: normalizedObjectType
           }
         }
         creator["getServiceOptions"] = async (options: NewObjectOptions) => {
@@ -682,7 +695,7 @@ export class AdtCommands {
           error: "CREATION_CANCELLED",
           message: "Object creation was cancelled or failed",
           objectName: name,
-          objectType: objectType
+          objectType: normalizedObjectType
         }
       }
 
@@ -731,7 +744,7 @@ export class AdtCommands {
           error: "OBJECT_ALREADY_EXISTS",
           message: errorMessage,
           objectName: name,
-          objectType: objectType
+          objectType: normalizeAiCreatableObjectType(objectType)
         }
       }
 
@@ -741,7 +754,7 @@ export class AdtCommands {
         error: "CREATION_FAILED",
         message: errorMessage,
         objectName: name,
-        objectType: objectType,
+        objectType: normalizeAiCreatableObjectType(objectType),
         stack: stack
       }
     }


### PR DESCRIPTION
## Summary

- Normalize AI function module aliases (`FUNC` and `FUNC/FF`) to the ADT creatable type `FUGR/FF`.
- Use the provided function group parent when creating function modules programmatically, instead of falling back to the current workspace hierarchy.
- Add focused command tests for alias normalization and explicit `FUGR/F` parent selection.
- Add a patch changeset for the release workflow.

## Validation

- `cd client && npm test -- --runTestsByPath src/commands/commands.test.ts --runInBand`
- `git diff --check upstream/master...HEAD`
- `npx @changesets/cli status --since=upstream/master`