### PR TITLE
Fix function module parent selection

### DIFF
--- a/.changeset/function-module-parent-selection.md
+++ b/.changeset/function-module-parent-selection.md
@@ -1,0 +1,5 @@
+---
+"vscode-abap-remote-fs": patch
+---
+
+Fix function module creation to use the provided function group parent instead of falling back to the current workspace hierarchy.

--- a/client/src/commands/commands.test.ts
+++ b/client/src/commands/commands.test.ts
@@ -192,7 +192,7 @@ jest.mock("../services/sapSystemInfo", () => ({
   clearSystemInfoCache: jest.fn()
 }))
 
-import { currentUri, currentAbapFile, currentEditState, openObject } from "./commands"
+import { currentUri, currentAbapFile, currentEditState, openObject, AdtCommands } from "./commands"
 import { funWindow as window } from "../services/funMessenger"
 import { ADTSCHEME, getRoot } from "../adt/conections"
 import { uriAbapFile } from "../adt/operations/AdtObjectFinder"
@@ -231,6 +231,30 @@ describe("currentUri", () => {
     const uri = makeAdtUri()
     ;(mockWindow as any).activeTextEditor = { document: { uri } }
     expect(currentUri()).toBe(uri)
+  })
+})
+
+describe("createAdtObjectProgrammatically", () => {
+  test("requires a parent function group when creating function modules", async () => {
+    const result = await AdtCommands.createAdtObjectProgrammatically(
+      "FUGR/FF" as any,
+      "Z_TEST_FUNCTION",
+      "Test function module",
+      "$TMP",
+      undefined,
+      "dev100"
+    )
+
+    const { AdtObjectCreator } = require("../adt/operations/AdtObjectCreator")
+
+    expect(result).toEqual({
+      success: false,
+      error: "MISSING_FUNCTION_GROUP_PARENT",
+      message: "Function module creation requires parentName with the parent function group name.",
+      objectName: "Z_TEST_FUNCTION",
+      objectType: "FUGR/FF"
+    })
+    expect(AdtObjectCreator).not.toHaveBeenCalled()
   })
 })
 

--- a/client/src/commands/commands.ts
+++ b/client/src/commands/commands.ts
@@ -602,6 +602,17 @@ export class AdtCommands {
     }
   ) {
     try {
+      if (objectType.toUpperCase() === "FUGR/FF" && !parentName?.trim()) {
+        return {
+          success: false,
+          error: "MISSING_FUNCTION_GROUP_PARENT",
+          message:
+            "Function module creation requires parentName with the parent function group name.",
+          objectName: name,
+          objectType: objectType
+        }
+      }
+
       // Use current connection or specified one
       const connId = connectionId || (await pickAdtRoot())?.uri.authority
       if (!connId) return
@@ -636,7 +647,7 @@ export class AdtCommands {
         if (type === "FUGR/F" && parentName) {
           // Function modules are function group children; AI creation must use the provided parent group
           // to avoid falling back to the current workspace location.
-          return parentName.toUpperCase()
+          return parentName.trim().toUpperCase()
         }
         // For other types, use original logic
         const original =

--- a/client/src/commands/commands.ts
+++ b/client/src/commands/commands.ts
@@ -633,6 +633,11 @@ export class AdtCommands {
           // PACKAGE type - this is what prevents the "Select package" dialog
           return packageName
         }
+        if (type === "FUGR/F" && parentName) {
+          // Function modules are function group children; AI creation must use the provided parent group
+          // to avoid falling back to the current workspace location.
+          return parentName.toUpperCase()
+        }
         // For other types, use original logic
         const original =
           hierarchy.filter((n: any) => n.object?.type === type)?.[0]?.object?.name || ""

--- a/package.json
+++ b/package.json
@@ -740,7 +740,7 @@
       {
         "name": "create_object_programmatically",
         "displayName": "Create ABAP Object Programmatically",
-        "modelDescription": "Creates new ABAP objects (classes, reports, function groups, etc.) programmatically without manual dialogs. Use this when the user wants to create new ABAP objects. Supports various object types including reports, classes, function groups, interfaces, data elements, and more.",
+        "modelDescription": "Creates new ABAP objects (classes, reports, function groups, function modules, etc.) programmatically without manual dialogs. Use this when the user wants to create new ABAP objects. For function modules, use objectType 'FUGR/FF' and always provide parentName with the parent function group name. Supports various object types including reports, classes, function groups, function modules, interfaces, data elements, and more.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "abap-create",
         "icon": "$(add)",
@@ -750,7 +750,7 @@
           "properties": {
             "objectType": {
               "type": "string",
-              "description": "Object type. Supports all SAP creatable object types including: 'PROG/P' (report), 'CLAS/OC' (class), 'FUGR/F' (function group), 'INTF/OI' (interface), 'DTEL/DE' (data element), 'TABL/DT' (database table), 'DDLS/DF' (CDS view), 'DOMA/DD' (domain), 'MSAG/N' (message class), 'DEVC/K' (package), 'SRVD/SRV' (service definition), 'SRVB/SVB' (service binding), 'BDEF/BDO' (behavior definition), and others. Use the format: TYPE/SUBTYPE"
+              "description": "Object type. Supports all SAP creatable object types including: 'PROG/P' (report), 'CLAS/OC' (class), 'FUGR/F' (function group), 'FUGR/FF' (function module, requires parentName with the parent function group), 'INTF/OI' (interface), 'DTEL/DE' (data element), 'TABL/DT' (database table), 'DDLS/DF' (CDS view), 'DOMA/DD' (domain), 'MSAG/N' (message class), 'DEVC/K' (package), 'SRVD/SRV' (service definition), 'SRVB/SVB' (service binding), 'BDEF/BDO' (behavior definition), and others. Use the format: TYPE/SUBTYPE"
             },
             "name": {
               "type": "string",
@@ -767,7 +767,7 @@
             },
             "parentName": {
               "type": "string",
-              "description": "Optional parent object for includes/methods"
+              "description": "Parent object name. Required for function modules ('FUGR/FF'): pass the parent function group name, not the function module name. Optional for other object types such as includes/methods."
             },
             "connectionId": {
               "type": "string",


### PR DESCRIPTION
## Summary

- Use the provided function group parent when creating function modules programmatically.
- Avoid falling back to the current workspace hierarchy for `FUGR/F` parent selection.

## Validation

- `cd client && npm test -- --runTestsByPath src/commands/commands.test.ts --runInBand`
- `git diff --check`