### PR TITLE
Security: HTML Injection in HttpProvider Custom Text Editor

### DIFF
--- a/.changeset/large-wolves-deny.md
+++ b/.changeset/large-wolves-deny.md
@@ -1,0 +1,5 @@
+---
+"vscode-abap-remote-fs": patch
+---
+
+escape name an value in http services editor

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   check-changeset:
     name: Check Changeset
+    if: github.actor != 'github-actions[bot]' || !contains(github.event.pull_request.title, 'Version Packages')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/client/src/editors/httpprovider.ts
+++ b/client/src/editors/httpprovider.ts
@@ -27,8 +27,10 @@ export class HttpProvider implements CustomTextEditorProvider {
       Uri.file(path.join(this.context.extensionPath, "client/media", "editor.css"))
     )
     const service = parseHTTP(source)
+    const escapeHtml = (s: string) =>
+      s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;")
     const field = (name: string, value: string) =>
-      `<tr><td><strong>${name}</strong></td><td>${value}</td></tr>`
+      `<tr><td><strong>${escapeHtml(name)}</strong></td><td>${escapeHtml(value)}</td></tr>`
     const tbody =
       field("Handler Class", service.handlerClass) +
       field("Author", service.author) +
@@ -47,7 +49,7 @@ export class HttpProvider implements CustomTextEditorProvider {
         }
         </script></head>
         <body>
-        <h1>${service.name} ${service.text}</h1>
+        <h1>${escapeHtml(service.name)} ${escapeHtml(service.text)}</h1>
         <table><tbody>${tbody}</tbody></table>
         </body></html>`
   }

--- a/client/src/editors/httpprovider.ts
+++ b/client/src/editors/httpprovider.ts
@@ -28,7 +28,12 @@ export class HttpProvider implements CustomTextEditorProvider {
     )
     const service = parseHTTP(source)
     const escapeHtml = (s: string) =>
-      s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;")
+      s
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;")
     const field = (name: string, value: string) =>
       `<tr><td><strong>${escapeHtml(name)}</strong></td><td>${escapeHtml(value)}</td></tr>`
     const tbody =


### PR DESCRIPTION
## Summary

Security: HTML Injection in HttpProvider Custom Text Editor

## Problem

**Severity**: `High` | **File**: `client/src/editors/httpprovider.ts:L28`

The `HttpProvider.toHtml()` method directly interpolates parsed XML values (`service.name`, `service.text`, `service.handlerClass`, `service.author`, `service.url`) into an HTML template without any sanitization. Since `parseHTTP` extracts these values from external XML data and they are rendered with `enableScripts: true`, malicious XML could inject arbitrary HTML/JS into the webview. This is a stored XSS vulnerability if an attacker can control the HTTP service XML definition.

## Solution

Sanitize all interpolated values before inserting into HTML. Use a library like DOMPurify, or at minimum escape HTML entities (`<`, `>`, `&`, `"`, `'`) for all dynamic values. Alternatively, use the VS Code webview API's `postMessage` for data transfer instead of inline HTML generation.

## Changes

- `client/src/editors/httpprovider.ts` (modified)