### PR TITLE
fix: use connection language as master language on object creation

### DIFF
--- a/.changeset/fix-object-creation-language.md
+++ b/.changeset/fix-object-creation-language.md
@@ -1,0 +1,5 @@
+---
+"vscode-abap-remote-fs": patch
+---
+
+Fix object creation forcing English master language. Created objects now use the connection's logon language instead of the hardcoded `"EN"` fallback in abap-adt-api's creation XML, so they can be created on non-English master systems.

--- a/client/src/adt/operations/AdtObjectCreator.test.ts
+++ b/client/src/adt/operations/AdtObjectCreator.test.ts
@@ -181,6 +181,57 @@ describe("AdtObjectCreator", () => {
     expect(Array.isArray(types)).toBe(true)
   })
 
+  it("createObject passes the connection language as master language", async () => {
+    // Regression: abap-adt-api hardcodes adtcore:masterLanguage="EN" when the
+    // create options carry no language. We must forward the connection language.
+    const createObject = jest.fn().mockResolvedValue(undefined)
+    const { getClient, getRoot } = require("../conections")
+    ;(getClient as jest.Mock).mockReturnValue({
+      username: "TESTUSER",
+      language: "DE",
+      validateNewObject: jest.fn().mockResolvedValue(true),
+      createObject
+    })
+    ;(getRoot as jest.Mock).mockReturnValue({
+      getNode: jest.fn().mockReturnValue(null),
+      getNodePath: jest.fn().mockReturnValue([]),
+      service: {}
+    })
+
+    const { funWindow } = require("../../services/funMessenger")
+    // guessOrSelectObjectType -> selectObjectType
+    ;(funWindow.showQuickPick as jest.Mock).mockResolvedValue({
+      typeId: "PROG/P",
+      label: "Program",
+      maxLen: 40
+    })
+    // askName, then askInput("description")
+    ;(funWindow.showInputBox as jest.Mock)
+      .mockResolvedValueOnce("ZPROG")
+      .mockResolvedValueOnce("desc")
+
+    const { AdtObjectFinder } = require("./AdtObjectFinder")
+    ;(AdtObjectFinder as jest.Mock).mockImplementation(() => ({
+      findObject: jest.fn().mockResolvedValue({ name: "ZPKG" }),
+      vscodeUriWithFile: jest.fn()
+    }))
+
+    const { selectTransport } = require("../AdtTransports")
+    ;(selectTransport as jest.Mock).mockResolvedValue({ cancelled: false, transport: "K123" })
+
+    const { fromNode } = require("abapobject")
+    ;(fromNode as jest.Mock).mockReturnValue({
+      name: "ZPROG",
+      type: "PROG/P",
+      loadStructure: jest.fn().mockResolvedValue(undefined)
+    })
+
+    await creator.createObject(undefined)
+
+    expect(createObject).toHaveBeenCalledTimes(1)
+    expect(createObject.mock.calls[0][0]).toMatchObject({ language: "DE" })
+  })
+
   it("createObject returns undefined when user cancels type selection", async () => {
     // createObject calls guessOrSelectObjectType which needs a non-empty hierarchy
     // With empty hierarchy, selectObjectType is called - mock it to return undefined (cancelled)

--- a/client/src/adt/operations/AdtObjectCreator.ts
+++ b/client/src/adt/operations/AdtObjectCreator.ts
@@ -311,7 +311,10 @@ export class AdtObjectCreator {
       objtype: objType.typeId,
       parentName,
       parentPath: objectPath(parentType, parentName, ""),
-      responsible
+      responsible,
+      // Use the connection's logon language as master language, otherwise
+      // abap-adt-api falls back to a hardcoded "EN" in the creation XML.
+      language: getClient(this.connId).language
     }
     if (options.objtype === "SRVB/SVB") {
       const o = await this.getServiceOptions(options)

--- a/client/src/commands/createObjectInEditor.ts
+++ b/client/src/commands/createObjectInEditor.ts
@@ -248,7 +248,10 @@ async function buildCreationDetails(connId: string, input: CreateObjectFormInput
     objtype: input.typeId,
     parentName,
     parentPath: objectPath(typeInfo.parentType as CreatableTypeIds, parentName, ""),
-    responsible
+    responsible,
+    // Use the connection's logon language as master language, otherwise
+    // abap-adt-api falls back to a hardcoded "EN" in the creation XML.
+    language: getClient(connId).language
   }
 
   if (typeInfo.isServiceBinding) {


### PR DESCRIPTION
## Problem

Creating any ABAP object (class, program, etc.) always sends `adtcore:masterLanguage="EN"` in the creation request, regardless of the connection's configured logon language. On systems whose master language is not English (e.g. DE), the create request is rejected — even though reads and edits work fine, because the ADT *session* language is set correctly from the connection config; only the create body ignored it.

## Root cause

Objects are created via `getClient(connId).createObject(options)`. The bundled `abap-adt-api` (8.4.1) builds the creation XML in `createBodySimple`:

```js
const language = options.language || "EN";                 // → adtcore:language="EN"
const masterLanguage = options.masterLanguage || language; // → adtcore:masterLanguage="EN"
```

When the caller passes no `language`, it falls back to a hardcoded `"EN"`. Neither of this extension's two create paths set a language on the options, so the fallback always won.

## Fix

Forward the connection's logon language (`ADTClient.language`, already exposed via `getClient(connId)`) onto the create options in both create paths, mirroring how the adjacent `responsible` field is already populated:

- `client/src/adt/operations/AdtObjectCreator.ts` — the quick-pick flow, which also backs the programmatic / AI language-model tool create command (both route through `getObjectDetails`).
- `client/src/commands/createObjectInEditor.ts` — the webview form flow.

`abap-adt-api` derives `masterLanguage` from `language` when the former is absent, so setting `language` fixes both attributes. It is harmless for packages and function modules, whose body builders don't emit a language attribute.

## Tests

Added a regression test in `AdtObjectCreator.test.ts` asserting `createObject` is called with the connection's language (`language: "DE"`). Full `AdtObjectCreator` suite passes (12/12).

## Note (out of scope)

Connections created via the OAuth wizard / connection manager still hardcode `language: "en"` (`connectionwizard.ts`, `sapConnectionManager.ts`) despite fetching the system's installed languages. That's a separate issue and not addressed here — happy to follow up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
