### PR TITLE
Execute command tool

### DIFF
--- a/.changeset/new-symbols-refuse.md
+++ b/.changeset/new-symbols-refuse.md
@@ -1,0 +1,5 @@
+---
+"vscode-abap-remote-fs": patch
+---
+
+add a new LM tool that lets Copilot run select ABAP FS commands

--- a/client/src/services/lm-tools/executeCommandTool.ts
+++ b/client/src/services/lm-tools/executeCommandTool.ts
@@ -1,0 +1,73 @@
+/**
+ * ABAP FS Execute Command Tool
+ *
+ * Thin wrapper around vscode.commands.executeCommand that lets Copilot trigger
+ * a curated allow-list of ABAP FS commands (comm log, debug recording, ...).
+ * The allow-list lives in the tool's package.json enum — the model literally
+ * cannot invoke anything outside it.
+ *
+ * Fire-and-forget only: return value is discarded, tool reports "triggered".
+ * Commands that need meaningful args or return structured data should get
+ * their own dedicated LM tool.
+ */
+
+import * as vscode from "vscode"
+import { registerToolWithRegistry } from "./toolRegistry"
+import { logTelemetry } from "../telemetry"
+import { assertToolInvocationAuthorized } from "./toolGuard"
+
+export interface IExecuteCommandParameters {
+  command: string
+}
+
+/**
+ * Commands the tool should await before returning. Anything not in this set is
+ * fired and forgotten — the tool reports "triggered" immediately. Add a command
+ * here when the model needs to know it finished before deciding what to do next
+ * (e.g. a setup / bootstrap command).
+ */
+const AWAIT_COMMANDS = new Set<string>(["abapfs.activateCommLog"])
+
+export class ExecuteCommandTool implements vscode.LanguageModelTool<IExecuteCommandParameters> {
+  async prepareInvocation(
+    options: vscode.LanguageModelToolInvocationPrepareOptions<IExecuteCommandParameters>,
+    _token: vscode.CancellationToken
+  ) {
+    const { command } = options.input
+    return {
+      invocationMessage: `Running ABAP FS command: ${command}`,
+      confirmationMessages: {
+        title: "Run ABAP FS Command",
+        message: new vscode.MarkdownString(`Run VS Code command:\n\n**\`${command}\`**`)
+      }
+    }
+  }
+
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<IExecuteCommandParameters>,
+    _token: vscode.CancellationToken
+  ): Promise<vscode.LanguageModelToolResult> {
+    assertToolInvocationAuthorized(options)
+    const { command } = options.input
+    logTelemetry("tool_execute_command_called", {})
+    logTelemetry(`command_${command}_called`, {})
+
+    if (AWAIT_COMMANDS.has(command)) {
+      await vscode.commands.executeCommand(command)
+      return new vscode.LanguageModelToolResult([
+        new vscode.LanguageModelTextPart(`Command \`${command}\` finished.`)
+      ])
+    }
+
+    void vscode.commands.executeCommand(command)
+    return new vscode.LanguageModelToolResult([
+      new vscode.LanguageModelTextPart(`Command \`${command}\` was triggered.`)
+    ])
+  }
+}
+
+export function registerExecuteCommandTool(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    registerToolWithRegistry("abap_execute_command", new ExecuteCommandTool())
+  )
+}

--- a/client/src/services/lm-tools/index.ts
+++ b/client/src/services/lm-tools/index.ts
@@ -18,6 +18,7 @@ import { registerGetObjectByUriTool } from "./getObjectByUriTool"
 import { registerCreateObjectTool } from "./createObjectTool"
 import { registerOpenObjectTool } from "./openObjectTool"
 import { registerDownloadTool } from "./downloadTool"
+import { registerExecuteCommandTool } from "./executeCommandTool"
 import { registerGetWorkspaceUriTool } from "./getWorkspaceUriTool"
 import { registerGetObjectUrlTool } from "./getObjectUrlTool"
 import { registerDocumentationTool } from "./documentationTool"
@@ -69,6 +70,7 @@ export async function registerAllTools(context: vscode.ExtensionContext): Promis
   registerCreateObjectTool(context)
   registerOpenObjectTool(context)
   registerDownloadTool(context)
+  registerExecuteCommandTool(context)
   registerGetWorkspaceUriTool(context)
   registerGetObjectUrlTool(context)
 

--- a/package.json
+++ b/package.json
@@ -1630,6 +1630,40 @@
         "when": "abapfs:extensionActive && !abapfs:noSapConnected"
       },
       {
+        "name": "abap_execute_command",
+        "displayName": "Run ABAP FS Command",
+        "modelDescription": "Trigger an allow-listed ABAP FS VS Code command. Use this tool to: activate/deactivate ADT communication log, start/stop debug replay recording, open the connection manager, launch the ABAP FS walkthrough, or open ADT feeds manager. Fire-and-forget by default (returns 'triggered'); a small set of setup-style commands wait until finished. No return value from the command itself — dedicated LM tools handle commands that need meaningful args or output.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "abap-run-command",
+        "icon": "$(play)",
+        "userDescription": "Trigger allow-listed ABAP FS commands (comm log, debug recording, connection manager, walkthrough, feeds manager)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string",
+              "enum": [
+                "abapfs.activateCommLog",
+                "abapfs.deactivateCommLog",
+                "abapfs.startRecording",
+                "abapfs.stopRecording",
+                "abapfs.connectionManager",
+                "abapfs.showWalkThrough",
+                "abapfs.configureFeeds"
+              ],
+              "description": "The ABAP FS command id to trigger. Only ids in this enum are allowed."
+            }
+          },
+          "required": [
+            "command"
+          ]
+        },
+        "tags": [
+          "abap-fs"
+        ],
+        "when": "abapfs:extensionActive"
+      },
+      {
         "name": "run_unit_tests",
         "displayName": "Run ABAP Unit Tests",
         "modelDescription": "Run ABAP unit tests for an object. Results shown in VS Code Testing panel with pass/fail.",


### PR DESCRIPTION
This PR adds a new LM tool that lets Copilot/other AI trigger whitelisted ABAP FS commands, could also be useful for upcoming abap_wiki setup.
PS: This brings tool count to 42!!