### PR TITLE
Text elements

### DIFF
--- a/.changeset/small-swans-lie.md
+++ b/.changeset/small-swans-lie.md
@@ -1,0 +1,5 @@
+---
+"vscode-abap-remote-fs": patch
+---
+
+text elements improvements

--- a/client/src/adt/textElements.test.ts
+++ b/client/src/adt/textElements.test.ts
@@ -239,6 +239,20 @@ describe("getTextElements (async)", () => {
     expect(result.programName).toBe("ZPROG")
   })
 
+  it("passes non-symbol categories through to the ADT client", async () => {
+    const getTextElementsFn = jest
+      .fn()
+      .mockResolvedValue({ textElements: [], programName: "ZPROG" })
+    const client: any = { getTextElements: getTextElementsFn }
+
+    await getTextElements(client, "ZPROG", undefined, "selections")
+
+    expect(getTextElementsFn).toHaveBeenCalledWith(
+      expect.stringContaining("/sap/bc/adt/textelements/programs/zprog"),
+      "selections"
+    )
+  })
+
   it("returns empty array on 404", async () => {
     const getTextElementsFn = jest.fn().mockRejectedValue({ response: { status: 404 } })
     const client: any = { getTextElements: getTextElementsFn }

--- a/client/src/adt/textElements.ts
+++ b/client/src/adt/textElements.ts
@@ -1,8 +1,14 @@
-import { ADTClient, AdtLock, TextElement, TextElementsResult } from "abap-adt-api"
+import {
+  ADTClient,
+  AdtLock,
+  TextElement,
+  TextElementsResult,
+  TextElementCategory
+} from "abap-adt-api"
 import { log } from "../lib"
 import { selectTransport } from "./AdtTransports"
 
-export type { TextElement, TextElementsResult }
+export type { TextElement, TextElementsResult, TextElementCategory }
 
 export interface LockResult {
   lockHandle: string
@@ -157,11 +163,12 @@ function getTextElementsBaseUrl(objectName: string, objectType?: string): string
 export async function getTextElements(
   connection: ADTClient,
   objectName: string,
-  objectType?: string
+  objectType?: string,
+  category: TextElementCategory = "symbols"
 ): Promise<TextElementsResult> {
   const url = getTextElementsBaseUrl(objectName, objectType)
   try {
-    return await connection.getTextElements(url, "symbols")
+    return await connection.getTextElements(url, category)
   } catch (error: any) {
     if (error.response?.status === 404) {
       return { textElements: [], programName: objectName.toUpperCase() }
@@ -197,11 +204,12 @@ export async function setTextElements(
   textElements: TextElement[],
   lockHandle: string,
   corrNr?: string,
-  objectType?: string
+  objectType?: string,
+  category: TextElementCategory = "symbols"
 ): Promise<void> {
   const url = getTextElementsBaseUrl(objectName, objectType)
   try {
-    await connection.setTextElements(url, "symbols", textElements, lockHandle, corrNr)
+    await connection.setTextElements(url, category, textElements, lockHandle, corrNr)
     await connection.unLock(url, lockHandle).catch(() => undefined)
     await connection.activate(objectName.toUpperCase(), url)
   } catch (error: any) {
@@ -221,13 +229,12 @@ function validateObjectName(objectName: string): void {
 /**
  * Validate text elements array
  */
-function validateTextElements(textElements: TextElement[]): void {
+function validateTextElements(
+  textElements: TextElement[],
+  category: TextElementCategory = "symbols"
+): void {
   if (!Array.isArray(textElements)) {
     throw new Error("Text elements must be an array")
-  }
-
-  if (textElements.length === 0) {
-    throw new Error("At least one text element is required")
   }
 
   const usedIds = new Set<string>()
@@ -248,19 +255,29 @@ function validateTextElements(textElements: TextElement[]): void {
     }
     usedIds.add(id)
 
-    // Auto-calculate maxLength if not provided or invalid
-    if (element.maxLength === undefined || element.maxLength === null || isNaN(element.maxLength)) {
-      element.maxLength = Math.max(element.text.length, 10) // At least 10, or text length
-    }
+    if (category === "symbols") {
+      // Auto-calculate maxLength if not provided or invalid
+      if (
+        element.maxLength === undefined ||
+        element.maxLength === null ||
+        isNaN(element.maxLength)
+      ) {
+        element.maxLength = Math.max(element.text.length, 10) // At least 10, or text length
+      }
 
-    if (typeof element.maxLength !== "number" || element.maxLength < 1 || element.maxLength > 255) {
-      throw new Error(`Invalid maxLength for element ${id}: must be between 1 and 255`)
-    }
+      if (
+        typeof element.maxLength !== "number" ||
+        element.maxLength < 1 ||
+        element.maxLength > 255
+      ) {
+        throw new Error(`Invalid maxLength for element ${id}: must be between 1 and 255`)
+      }
 
-    if (element.text.length > element.maxLength) {
-      throw new Error(
-        `Text length exceeds maxLength for element ${id}: ${element.text.length} > ${element.maxLength}`
-      )
+      if (element.text.length > element.maxLength) {
+        throw new Error(
+          `Text length exceeds maxLength for element ${id}: ${element.text.length} > ${element.maxLength}`
+        )
+      }
     }
   }
 }
@@ -271,20 +288,22 @@ function validateTextElements(textElements: TextElement[]): void {
 export async function getTextElementsSafe(
   connection: ADTClient,
   objectName: string,
-  objectType?: string
+  objectType?: string,
+  category: TextElementCategory = "symbols"
 ): Promise<TextElementsResult> {
   validateObjectName(objectName)
-  return getTextElements(connection, objectName, objectType)
+  return getTextElements(connection, objectName, objectType, category)
 }
 
 export async function updateTextElementsWithTransport(
   connection: ADTClient,
   objectName: string,
   textElements: TextElement[],
-  objectType?: string // Optional - only required when called from Copilot
+  objectType?: string, // Optional - only required when called from Copilot
+  category: TextElementCategory = "symbols"
 ): Promise<void> {
   validateObjectName(objectName)
-  validateTextElements(textElements)
+  validateTextElements(textElements, category)
 
   let lockResult: LockResult | undefined
 
@@ -319,7 +338,8 @@ export async function updateTextElementsWithTransport(
       textElements,
       lockResult.lockHandle,
       transportToUse,
-      objectType
+      objectType,
+      category
     )
   } catch (error) {
     if (lockResult) {

--- a/client/src/commands/textElementsCommands.test.ts
+++ b/client/src/commands/textElementsCommands.test.ts
@@ -175,8 +175,16 @@ describe("manageTextElementsCommand", () => {
 
     expect(mockGetTextElementsSafe).toHaveBeenCalledWith(
       expect.anything(),
-      expect.stringContaining("ZMAINPROG")
+      expect.stringContaining("ZMAINPROG"),
+      undefined,
+      "symbols"
     )
+    expect(mockGetTextElementsSafe).toHaveBeenCalledTimes(3)
+    expect(mockGetTextElementsSafe.mock.calls.map(call => call[3])).toEqual([
+      "symbols",
+      "selections",
+      "headings"
+    ])
   })
 
   test("shows error when object name cannot be determined", async () => {

--- a/client/src/commands/textElementsCommands.ts
+++ b/client/src/commands/textElementsCommands.ts
@@ -4,7 +4,8 @@ import { getClient, getRoot } from "../adt/conections"
 import {
   getTextElementsSafe,
   updateTextElementsWithTransport,
-  TextElement
+  TextElement,
+  TextElementCategory
 } from "../adt/textElements"
 import { logCommands } from "../services/abapCopilotLogger"
 import { session_types } from "abap-adt-api"
@@ -13,6 +14,26 @@ import { isAbapFile } from "abapfs"
 import { parseObjectName } from "../adt/textElements"
 import { SapGuiPanel } from "../views/sapgui/SapGuiPanel"
 import { RemoteManager } from "../config"
+
+const TEXT_ELEMENT_CATEGORIES: TextElementCategory[] = ["symbols", "selections", "headings"]
+type TextElementsByCategory = Record<TextElementCategory, TextElement[]>
+
+async function getAllTextElements(
+  client: Parameters<typeof getTextElementsSafe>[0],
+  objectName: string
+): Promise<TextElementsByCategory> {
+  const [symbols, selections, headings] = await Promise.all(
+    TEXT_ELEMENT_CATEGORIES.map(category =>
+      getTextElementsSafe(client, objectName, undefined, category)
+    )
+  )
+
+  return {
+    symbols: symbols.textElements,
+    selections: selections.textElements,
+    headings: headings.textElements
+  }
+}
 
 /**
  * Map an ABAP object type (e.g. "PROG/P") to the pseudo-filename suffix that
@@ -159,12 +180,12 @@ async function showTextElementsEditor(programName: string, sourceUri: vscode.Uri
       try {
         progress.report({ increment: 30, message: "Fetching text elements..." })
 
-        const result = await getTextElementsSafe(client, programName)
+        const textElements = await getAllTextElements(client, programName)
 
         progress.report({ increment: 70, message: "Opening editor..." })
 
         // Create and show text elements manager webview
-        await createTextElementsWebview(programName, result.textElements, connectionId, sourceUri)
+        await createTextElementsWebview(programName, textElements, connectionId)
       } catch (error) {
         // Check if it's a "Resource does not exist" error - fallback to SAP GUI for old systems
         const errorMessage = String(error)
@@ -293,9 +314,8 @@ export async function openTextElementsInSapGui(
  */
 async function createTextElementsWebview(
   programName: string,
-  textElements: TextElement[],
-  connectionId: string,
-  sourceUri: vscode.Uri
+  textElements: TextElementsByCategory,
+  connectionId: string
 ): Promise<void> {
   const panel = window.createWebviewPanel(
     "textElementsManager",
@@ -320,9 +340,9 @@ async function createTextElementsWebview(
         await handleSaveTextElements(
           programName,
           message.textElements,
+          message.category || "symbols",
           panel,
-          connectionId,
-          sourceUri
+          connectionId
         )
         break
 
@@ -352,9 +372,9 @@ async function createTextElementsWebview(
 async function handleSaveTextElements(
   programName: string,
   textElements: TextElement[],
+  category: TextElementCategory,
   panel: vscode.WebviewPanel,
-  connectionId: string,
-  sourceUri: vscode.Uri
+  connectionId: string
 ): Promise<void> {
   try {
     // Get client using the connectionId from the original context - get original client, not clone
@@ -365,36 +385,15 @@ async function handleSaveTextElements(
     }
     client.stateful = session_types.stateful
 
-    await window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: `Saving text elements for ${programName}...`,
-        cancellable: false
-      },
-      async progress => {
-        progress.report({ increment: 30, message: "Validating..." })
+    const validTextElements = textElements.filter(te => te.id && te.text)
 
-        // Filter out empty text elements
-        const validTextElements = textElements.filter(te => te.id && te.text)
-
-        if (validTextElements.length === 0) {
-          throw new Error("No valid text elements to save")
-        }
-
-        progress.report({ increment: 60, message: "Saving to SAP system..." })
-        //changed below line to not use lock manager version of function
-        await updateTextElementsWithTransport(
-          client,
-          programName,
-          validTextElements,
-          sourceUri.toString()
-        )
-
-        progress.report({ increment: 100, message: "Saved successfully" })
-      }
+    await updateTextElementsWithTransport(
+      client,
+      programName,
+      validTextElements,
+      undefined,
+      category
     )
-
-    window.showInformationMessage(`Text elements saved successfully for ${programName}`)
 
     // Send success message to webview
     panel.webview.postMessage({ command: "saveSuccess" })
@@ -428,12 +427,12 @@ async function handleRefreshTextElements(
     }
 
     // Reload text elements from SAP
-    const result = await getTextElementsSafe(client, programName)
+    const textElements = await getAllTextElements(client, programName)
 
     // Send updated data to webview
     panel.webview.postMessage({
       command: "refresh",
-      textElements: result.textElements
+      textElements
     })
   } catch (error: any) {
     logCommands.error(`Error refreshing text elements: ${error}`)
@@ -450,7 +449,10 @@ async function handleRefreshTextElements(
 /**
  * Generate HTML content for text elements webview
  */
-function getTextElementsWebviewContent(programName: string, textElements: TextElement[]): string {
+function getTextElementsWebviewContent(
+  programName: string,
+  textElements: TextElementsByCategory
+): string {
   const textElementsJson = JSON.stringify(textElements)
 
   return `<!DOCTYPE html>
@@ -507,6 +509,7 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
         table {
             width: 100%;
             border-collapse: collapse;
+          table-layout: fixed;
             margin-top: 10px;
         }
         th, td {
@@ -515,8 +518,23 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
             text-align: left;
         }
         th {
+          position: relative;
+        }
+        th {
             background-color: var(--vscode-list-headerBackground);
             font-weight: bold;
+        }
+        .column-resizer {
+          position: absolute;
+          top: 0;
+          right: -5px;
+          width: 10px;
+          height: 100%;
+          cursor: col-resize;
+          z-index: 1;
+        }
+        .column-resizer:hover {
+          background-color: var(--vscode-focusBorder);
         }
         tr:nth-child(even) {
             background-color: var(--vscode-list-evenBackground);
@@ -535,24 +553,28 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
         input:focus {
             outline: 1px solid var(--vscode-focusBorder);
         }
+        .ddic-reference-cell input[type="checkbox"] {
+          width: auto;
+        }
         .id-input {
-            width: 80px;
+          width: 100%;
         }
         .maxlength-input {
             width: 80px;
         }
         .delete-btn {
-            background-color: var(--vscode-button-secondaryBackground);
-            color: var(--vscode-button-secondaryForeground);
-            border: none;
+          background-color: var(--vscode-button-background);
+          color: var(--vscode-button-foreground);
+          border: 1px solid var(--vscode-button-background);
             padding: 4px 8px;
             border-radius: 3px;
             cursor: pointer;
             font-size: 11px;
         }
         .delete-btn:hover {
-            background-color: var(--vscode-errorBackground);
-            color: var(--vscode-errorForeground);
+          background-color: var(--vscode-errorBackground, #c42b2b);
+          border-color: var(--vscode-errorBackground, #c42b2b);
+          color: var(--vscode-errorForeground, #ffffff);
         }
         .status {
             margin-top: 10px;
@@ -591,6 +613,22 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
             color: var(--vscode-descriptionForeground);
             font-size: 11px;
         }
+        .tabs {
+          display: flex;
+          gap: 4px;
+          margin-bottom: 12px;
+        }
+        .tab {
+          background: transparent;
+          color: var(--vscode-foreground);
+          border: 1px solid var(--vscode-panel-border);
+          padding: 6px 12px;
+          cursor: pointer;
+        }
+        .tab.active {
+          background-color: var(--vscode-button-background);
+          color: var(--vscode-button-foreground);
+        }
     </style>
 </head>
 <body>
@@ -598,26 +636,33 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
         <div class="title">� Text Elements Manager - ${programName}</div>
         <div class="buttons">
             <button class="btn secondary" onclick="refreshTextElements()">🔄 Refresh</button>
-            <button class="btn secondary" onclick="addRow()">➕ Add Text Element</button> 
+            <button id="addButton" class="btn secondary" onclick="addRow()">➕ Add Text Symbol</button> 
             <button class="btn" onclick="saveTextElements()">💾 Save & Activate</button>
         </div>
     </div>
+
+      <div class="tabs" role="tablist" aria-label="Text element category">
+        <button class="tab active" data-category="symbols" onclick="selectCategory('symbols')">Text Symbols</button>
+        <button class="tab" data-category="selections" onclick="selectCategory('selections')">Selection Texts</button>
+        <button class="tab" data-category="headings" onclick="selectCategory('headings')">List Headings</button>
+      </div>
     
     <div id="status" class="status"></div>
     
     <div class="program-info">
-        <strong>Object:</strong> ${programName} | <strong>Text Elements:</strong> <span id="elementCount">${textElements.length}</span>
+      <strong>Object:</strong> ${programName} | <strong>Text Elements:</strong> <span id="elementCount">${textElements.symbols.length}</span>
     </div>
     
     <div id="content">
         <table id="textElementsTable">
             <thead>
                 <tr>
-                    <th class="row-number">#</th>
-                    <th>ID</th>
-                    <th>Text</th>
-                    <th>Max Length</th>
-                    <th>Actions</th>
+                    <th class="row-number">#<span class="column-resizer" data-column="0"></span></th>
+                    <th>ID<span class="column-resizer" data-column="1"></span></th>
+                    <th>Text<span class="column-resizer" data-column="2"></span></th>
+                    <th>Max Length<span class="column-resizer" data-column="3"></span></th>
+                    <th id="ddicReferenceHeader">DDIC Reference<span class="column-resizer" data-column="4"></span></th>
+                    <th>Actions<span class="column-resizer" data-column="5"></span></th>
                 </tr>
             </thead>
             <tbody id="tableBody">
@@ -632,7 +677,67 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
 
     <script>
         const vscode = acquireVsCodeApi();
-        let textElements = ${textElementsJson};
+        const categoryLabels = {
+          symbols: 'Text Symbol',
+          selections: 'Selection Text',
+          headings: 'List Heading'
+        };
+        const table = document.getElementById('textElementsTable');
+        let textElementsByCategory = ${textElementsJson};
+        let activeCategory = 'symbols';
+        let textElements = textElementsByCategory[activeCategory] || [];
+        let pendingDeleteIndex = -1;
+
+        function updateDdicColumnVisibility() {
+          const visible = activeCategory === 'selections';
+          document.getElementById('ddicReferenceHeader').hidden = !visible;
+          document.querySelectorAll('.ddic-reference-cell').forEach(cell => {
+            cell.hidden = !visible;
+          });
+        }
+
+        function updateAddButton() {
+          const addButton = document.getElementById('addButton');
+          addButton.hidden = activeCategory !== 'symbols';
+          addButton.textContent = '➕ Add ' + categoryLabels[activeCategory];
+        }
+
+        function selectCategory(category) {
+          activeCategory = category;
+          textElements = textElementsByCategory[category] || [];
+          document.querySelectorAll('.tab').forEach(tab => {
+            tab.classList.toggle('active', tab.dataset.category === category);
+          });
+            updateAddButton();
+          updateDdicColumnVisibility();
+          renderTable();
+          updateElementCount();
+        }
+
+          document.querySelectorAll('.column-resizer').forEach(resizer => {
+            resizer.addEventListener('pointerdown', event => {
+              event.preventDefault();
+              event.stopPropagation();
+              const column = Number(resizer.dataset.column);
+              const startX = event.clientX;
+              const header = table.querySelector('thead th:nth-child(' + (column + 1) + ')');
+              const startWidth = header.getBoundingClientRect().width;
+
+              const resize = moveEvent => {
+                const width = Math.max(48, startWidth + moveEvent.clientX - startX);
+                table.querySelectorAll('tr > *:nth-child(' + (column + 1) + ')').forEach(cell => {
+                  cell.style.width = width + 'px';
+                });
+              };
+              const stopResize = () => {
+                document.removeEventListener('pointermove', resize);
+                document.removeEventListener('pointerup', stopResize);
+              };
+
+              document.addEventListener('pointermove', resize);
+              document.addEventListener('pointerup', stopResize);
+            });
+          });
         
         function renderTable() {
             const tbody = document.getElementById('tableBody');
@@ -655,22 +760,32 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
                              maxlength="8"
                              pattern="[A-Z0-9_]*"
                              title="1-8 characters, letters, numbers, underscore only"
-                             placeholder="e.g., 001">
+                         placeholder="e.g., 001"
+                         \${element.id ? 'readonly' : ''}>
                     </td>
                     <td>
                         <input type="text" value="\${element.text || ''}" 
                              onchange="updateElement(\${index}, 'text', this.value)"
-                             placeholder="Enter text content"> 
+                         placeholder="Enter text content"
+                         \${element.ddicReference ? 'readonly' : ''}> 
                     </td>
                     <td>
                         <input type="number" class="maxlength-input" value="\${element.maxLength || ''}" 
                              onchange="updateElement(\${index}, 'maxLength', parseInt(this.value))"
                              min="1" max="255"
                              placeholder="Auto"
-                             title="Maximum length for this text element">
+                         title="Maximum length for this text element"
+                         \${activeCategory !== 'symbols' ? 'disabled' : ''}>
+                    </td>
+                    <td class="ddic-reference-cell" \${activeCategory !== 'selections' ? 'hidden' : ''}>
+                      <input type="checkbox"
+                         \${element.ddicReference ? 'checked' : ''}
+                         \${!element.ddicReference ? 'disabled' : ''}
+                         onchange="updateDdicReference(\${index}, this.checked)"
+                         title="DDIC reference supplied by ADT">
                     </td>
                     <td>
-                        <button class="delete-btn" onclick="deleteRow(\${index})" title="Delete this text element">🗑️</button>
+                      <button class="delete-btn" onclick="deleteRow(\${index})" title="Delete this text element">\${pendingDeleteIndex === index ? 'Confirm' : '🗑️'}</button>
                     </td> 
                 </tr>
             \`).join('');
@@ -679,16 +794,20 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
         // 🚫 DISABLED: Add row functionality disabled due to lock handle issues
         
         function addRow() {
+          if (activeCategory !== 'symbols') return;
+
             // Auto-generate next available ID
             const usedIds = new Set(textElements.map(te => te.id).filter(id => id));
             let nextId = '';
             
             // Find next available numeric ID (001, 002, etc.)
-            for (let i = 1; i <= 999; i++) {
+            if (activeCategory === 'symbols') {
+              for (let i = 1; i <= 999; i++) {
                 const candidateId = i.toString().padStart(3, '0');
                 if (!usedIds.has(candidateId)) {
-                    nextId = candidateId;
-                    break;
+                  nextId = candidateId;
+                  break;
+                }
                 }
             }
             
@@ -709,15 +828,21 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
         function refreshTextElements() {
             showStatus('success', 'Refreshing text elements...');
             vscode.postMessage({
-                command: 'refresh'
+              command: 'refresh',
+              category: activeCategory
             });
         }
         
-        // 🚫 DISABLED: Delete row functionality disabled due to lock handle issues
-        
         function deleteRow(index) {
-            if (confirm(\`Delete text element '\${textElements[index].id}' - '\${textElements[index].text}'?\`)) {
+          if (pendingDeleteIndex !== index) {
+            pendingDeleteIndex = index;
+            renderTable();
+            return;
+          }
+
+          if (pendingDeleteIndex === index) {
                 textElements.splice(index, 1);
+            pendingDeleteIndex = -1;
                 renderTable();
                 updateElementCount();
             }
@@ -738,7 +863,7 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
             textElements[index][field] = value;
             
             // Auto-update maxLength based on text length if it's currently undefined/empty
-            if (field === 'text' && value) {
+            if (field === 'text' && value && activeCategory === 'symbols') {
                 const currentMaxLength = textElements[index].maxLength;
                 if (!currentMaxLength || currentMaxLength === '' || isNaN(currentMaxLength)) {
                     // Auto-calculate: at least text length + some buffer (minimum 10)
@@ -754,6 +879,12 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
                 }
             }
         }
+
+          function updateDdicReference(index, checked) {
+            if (!checked) {
+              delete textElements[index].ddicReference;
+            }
+          }
         
         
         // 🚫 DISABLED: Save functionality disabled due to lock handle issues
@@ -776,7 +907,7 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
                     errors.push(\`Row \${index + 1}: Text is required\`);
                 }
                 
-                if (element.maxLength && element.text && element.text.length > element.maxLength) {
+                if (activeCategory === 'symbols' && element.maxLength && element.text && element.text.length > element.maxLength) {
                     errors.push(\`Row \${index + 1}: Text length (\${element.text.length}) exceeds max length (\${element.maxLength})\`);
                 }
             });
@@ -786,10 +917,9 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
                 return;
             }
             
-            // Filter out empty rows
             const validElements = textElements.filter(te => te.id && te.text);
-            
-            if (validElements.length === 0) {
+
+            if (textElements.length > 0 && validElements.length === 0) {
                 showStatus('error', 'No valid text elements to save');
                 return;
             }
@@ -797,7 +927,8 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
             showStatus('success', 'Saving...');
             vscode.postMessage({
                 command: 'save',
-                textElements: validElements
+              category: activeCategory,
+              textElements: validElements
             });
         }
         
@@ -830,7 +961,8 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
                 
                 case 'refresh':
                     // Update textElements array and re-render
-                    textElements = message.textElements || [];
+                  textElementsByCategory = message.textElements || {};
+                  textElements = textElementsByCategory[activeCategory] || [];
                     renderTable();
                     updateElementCount();
                     showStatus('success', 'Text elements refreshed successfully!');
@@ -841,7 +973,8 @@ function getTextElementsWebviewContent(programName: string, textElements: TextEl
             }
         });
         
-        // Initial render
+        updateAddButton();
+        updateDdicColumnVisibility();
         renderTable();
     </script>
 </body>

--- a/client/src/services/lm-tools/textElementsTools.test.ts
+++ b/client/src/services/lm-tools/textElementsTools.test.ts
@@ -175,11 +175,36 @@ describe("ManageTextElementsTool", () => {
         mockToken
       )
 
-      expect(getTextElementsSafe).toHaveBeenCalledWith(mockClient, "ZREPORT", "PROGRAM")
+      expect(getTextElementsSafe).toHaveBeenCalledWith(mockClient, "ZREPORT", "PROGRAM", "symbols")
       expect(result.parts[0].text).toContain("ZREPORT")
       expect(result.parts[0].text).toContain("001")
       expect(result.parts[0].text).toContain("Hello")
       expect(result.parts[0].text).toContain("max: 20")
+    })
+
+    it("passes the requested category to the ADT helper", async () => {
+      ;(getTextElementsSafe as jest.Mock).mockResolvedValue({
+        programName: "ZREPORT",
+        textElements: [{ id: "P_NAME", text: "Name" }]
+      })
+
+      await tool.invoke(
+        makeOptions({
+          objectName: "ZREPORT",
+          objectType: "PROGRAM",
+          category: "selections",
+          action: "read",
+          connectionId: "dev100"
+        }),
+        mockToken
+      )
+
+      expect(getTextElementsSafe).toHaveBeenCalledWith(
+        mockClient,
+        "ZREPORT",
+        "PROGRAM",
+        "selections"
+      )
     })
 
     it("reports empty text elements", async () => {
@@ -337,6 +362,24 @@ describe("ManageTextElementsTool", () => {
       ).rejects.toThrow("Text elements array is required")
     })
 
+    it("rejects create for selection texts before contacting SAP", async () => {
+      await expect(
+        tool.invoke(
+          makeOptions({
+            objectName: "ZREPORT",
+            objectType: "PROGRAM",
+            category: "selections",
+            action: "create",
+            textElements: [{ id: "P_NEW", text: "New" }],
+            connectionId: "dev100"
+          }),
+          mockToken
+        )
+      ).rejects.toThrow("supports update only")
+
+      expect(getClient).not.toHaveBeenCalled()
+    })
+
     it("calls updateTextElementsWithTransport for create with merged elements", async () => {
       ;(getTextElementsSafe as jest.Mock).mockResolvedValue({
         programName: "ZREPORT",
@@ -363,7 +406,8 @@ describe("ManageTextElementsTool", () => {
           expect.objectContaining({ id: "001", text: "Existing" }),
           expect.objectContaining({ id: "002", text: "New Element" })
         ]),
-        "PROGRAM"
+        "PROGRAM",
+        "symbols"
       )
       expect(result.parts[0].text).toContain("Created")
     })
@@ -419,7 +463,8 @@ describe("ManageTextElementsTool", () => {
         mockClient,
         "ZREPORT",
         [{ id: "001", text: "Only New" }],
-        "PROGRAM"
+        "PROGRAM",
+        "symbols"
       )
       expect(result.parts[0].text).toContain("Created")
     })

--- a/client/src/services/lm-tools/textElementsTools.ts
+++ b/client/src/services/lm-tools/textElementsTools.ts
@@ -4,7 +4,11 @@ import { logCommands } from "../abapCopilotLogger"
 import { session_types } from "abap-adt-api"
 import { logTelemetry } from "../telemetry"
 import { getClient, abapUri } from "../../adt/conections"
-import { getTextElementsSafe, updateTextElementsWithTransport } from "../../adt/textElements"
+import {
+  getTextElementsSafe,
+  updateTextElementsWithTransport,
+  TextElementCategory
+} from "../../adt/textElements"
 import { openTextElementsInSapGui } from "../../commands/textElementsCommands"
 import { assertToolInvocationAuthorized } from "./toolGuard"
 
@@ -12,6 +16,7 @@ import { assertToolInvocationAuthorized } from "./toolGuard"
 export interface IManageTextElementsParameters {
   objectName: string // Name of the ABAP object
   objectType: "PROGRAM" | "CLASS" | "FUNCTION_GROUP" // Type of object (mandatory for Language Model Tool - Copilot provides this)
+  category?: TextElementCategory
   action: "read" | "create" | "update"
   textElements?: Array<{
     id: string
@@ -29,13 +34,24 @@ export class ManageTextElementsTool implements vscode.LanguageModelTool<IManageT
     options: vscode.LanguageModelToolInvocationPrepareOptions<IManageTextElementsParameters>,
     _token: vscode.CancellationToken
   ) {
-    const { objectName, objectType, action, textElements, connectionId } = options.input
+    const {
+      objectName,
+      objectType,
+      category = "symbols",
+      action,
+      textElements,
+      connectionId
+    } = options.input
 
     let message = `**Action:** ${action.toUpperCase()}\n**Object:** ${objectName}`
     if (objectType) {
       message += `\n**Type:** ${objectType}`
     }
+    message += `\n**Category:** ${category}`
     message += `\n**Connection:** ${connectionId || "auto-detect"}`
+    if (action === "create" && category !== "symbols") {
+      message += `\n**Note:** ${category} can only be updated; new entries cannot be created.`
+    }
 
     if (action === "create" || action === "update") {
       message += `\n**Text Elements:** ${textElements?.length || 0}`
@@ -62,8 +78,21 @@ export class ManageTextElementsTool implements vscode.LanguageModelTool<IManageT
     _token: vscode.CancellationToken
   ): Promise<vscode.LanguageModelToolResult> {
     assertToolInvocationAuthorized(options)
-    let { objectName, objectType, action, textElements, connectionId } = options.input
+    let {
+      objectName,
+      objectType,
+      category = "symbols",
+      action,
+      textElements,
+      connectionId
+    } = options.input
     logTelemetry("tool_manage_text_elements_called", { connectionId })
+
+    if (action === "create" && category !== "symbols") {
+      throw new Error(
+        `Cannot create ${category} text elements. ${category} supports update only; use action "update" for existing entries.`
+      )
+    }
 
     // 🚫 FORCE READ ACTION ONLY - Create/Update disabled due to lock handle issues
     // if (action === 'create' || action === 'update') {
@@ -102,7 +131,7 @@ export class ManageTextElementsTool implements vscode.LanguageModelTool<IManageT
       }
 
       if (action === "read") {
-        return await this.handleRead(client, objectName, objectType, actualConnectionId)
+        return await this.handleRead(client, objectName, objectType, category, actualConnectionId)
       } else if (action === "create" || action === "update") {
         if (!textElements || textElements.length === 0) {
           throw new Error("Text elements array is required for create/update operations")
@@ -111,7 +140,7 @@ export class ManageTextElementsTool implements vscode.LanguageModelTool<IManageT
         // For both CREATE and UPDATE, merge with existing text elements to avoid data loss
         let finalTextElements = textElements
         try {
-          const existingResult = await getTextElementsSafe(client, objectName, objectType)
+          const existingResult = await getTextElementsSafe(client, objectName, objectType, category)
           const existingElements = existingResult.textElements
 
           if (existingElements.length > 0) {
@@ -139,6 +168,7 @@ export class ManageTextElementsTool implements vscode.LanguageModelTool<IManageT
           client,
           objectName,
           objectType,
+          category,
           finalTextElements,
           action
         )
@@ -155,11 +185,12 @@ export class ManageTextElementsTool implements vscode.LanguageModelTool<IManageT
     client: any,
     objectName: string,
     objectType?: string,
+    category: TextElementCategory = "symbols",
     connectionId?: string
   ): Promise<vscode.LanguageModelToolResult> {
     try {
       // Use explicit object type when provided, fallback to detection when not
-      const result = await getTextElementsSafe(client, objectName, objectType)
+      const result = await getTextElementsSafe(client, objectName, objectType, category)
 
       let resultText = `Text Elements for ${result.programName}\n`
       resultText += `Object: ${result.programName} | Total: ${result.textElements.length}\n\n`
@@ -215,11 +246,12 @@ export class ManageTextElementsTool implements vscode.LanguageModelTool<IManageT
     client: any,
     objectName: string,
     objectType: string | undefined,
+    category: TextElementCategory,
     textElements: Array<{ id: string; text: string; maxLength?: number }>,
     action: "create" | "update"
   ): Promise<vscode.LanguageModelToolResult> {
     // Transport-aware function imported statically at module top
-    await updateTextElementsWithTransport(client, objectName, textElements, objectType)
+    await updateTextElementsWithTransport(client, objectName, textElements, objectType, category)
 
     let resultText = `Text Elements ${action === "create" ? "Created" : "Updated"} for ${objectName}\n`
     resultText += `Object: ${objectName} | ${action === "create" ? "Created" : "Updated"}: ${textElements.length}\n\n`
@@ -230,10 +262,12 @@ export class ManageTextElementsTool implements vscode.LanguageModelTool<IManageT
       resultText += `• ${element.id}: "${element.text}"${maxLengthInfo}\n`
     })
 
-    resultText += `\nSuccess. Next: update ABAP code to use these elements:`
-    textElements.forEach(element => {
-      resultText += `\n• Replace hardcoded text with: TEXT-${element.id}`
-    })
+    if (category === "symbols") {
+      resultText += `\nSuccess. Next: update ABAP code to use these elements:`
+      textElements.forEach(element => {
+        resultText += `\n• Replace hardcoded text with: TEXT-${element.id}`
+      })
+    }
 
     logCommands.info(
       ` ${action} Text Elements: Successfully processed ${textElements.length} text elements`

--- a/package.json
+++ b/package.json
@@ -1841,11 +1841,11 @@
       {
         "name": "manage_text_elements",
         "displayName": "Manage Text Elements",
-        "modelDescription": "Read, create, or update text elements (translatable strings) in programs, classes, function groups.",
+        "modelDescription": "Read, create, or update text elements in programs, classes, and function groups. Create is supported only for text symbols. Selection texts and list headings are update-only. Pass category 'selections' or 'headings' for those categories; omit it only for text symbols.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "text-elements-manager",
         "icon": "$(symbol-text)",
-        "userDescription": "Manage text elements in ABAP programs, classes, and function groups",
+        "userDescription": "Manage text symbols, selection texts, and list headings in ABAP programs, classes, and function groups",
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -1862,6 +1862,15 @@
               ],
               "description": "Type of ABAP object: 'PROGRAM' for reports/programs, 'CLASS' for classes, 'FUNCTION_GROUP' for function groups"
             },
+            "category": {
+              "type": "string",
+              "enum": [
+                "symbols",
+                "selections",
+                "headings"
+              ],
+              "description": "Text category. Create is supported only for 'symbols'. Pass 'selections' for selection texts or 'headings' for list headings; those categories are update-only. Omit this only for text symbols (default)."
+            },
             "action": {
               "type": "string",
               "enum": [
@@ -1869,7 +1878,7 @@
                 "create",
                 "update"
               ],
-              "description": "Action to perform: 'read' to get existing text elements, 'create' to add new ones, 'update' to modify existing ones"
+              "description": "Action to perform: 'read' to get existing entries, 'create' to add text symbols only, or 'update' to modify existing symbols, selection texts, or list headings"
             },
             "textElements": {
               "type": "array",
@@ -1880,7 +1889,7 @@
                   "id": {
                     "type": "string",
                     "description": "Text element ID (e.g., '001', '002', 'BTN')",
-                    "pattern": "^[A-Z0-9_]{1,8}$"
+                    "pattern": "^[A-Za-z0-9_]{1,20}$"
                   },
                   "text": {
                     "type": "string",


### PR DESCRIPTION
This PR improves text elements management (#507 )- both the manager and the LM tool

A potential issue in ADT API that needs to be addressed: The SAP ADT selection-text endpoint represents a DDIC-linked field with a standalone marker:

@DDICReference
P_DEVCLS=Package

abap-adt-api expects and writes:
@DDICReference:<value>

Consequences:

Existing DDIC links are not detected when reading.
Saving selection texts silently removes DDIC links.
Sending the colon format causes SAP’s parser to reject the request.

Fix: Model ddicReference as a boolean (or equivalent), parse the standalone @DDICReference marker, and serialize exactly that marker before the field. No DDIC field name should be included.