### PR TITLE
Enable XML editing for domains and table types

### DIFF
--- a/.changeset/tidy-domains-read.md
+++ b/.changeset/tidy-domains-read.md
@@ -1,0 +1,5 @@
+---
+"vscode-abap-remote-fs": patch
+---
+
+Route domains and table types through the XML editor so their definitions can be read and saved at the DDIC object endpoint.

--- a/modules/abapObject/src/AbapObject.ts
+++ b/modules/abapObject/src/AbapObject.ts
@@ -114,9 +114,7 @@ export class AbapObjectBase implements AbapObject {
     protected readonly service: AbapObjectService,
     readonly owner?: string
   ) {
-    this.supported =
-      this.type !== "IWSV" &&
-      !path.match("(/sap/bc/adt/vit)|(/sap/bc/adt/ddic/domains/)|(/sap/bc/esproxy)")
+    this.supported = this.type !== "IWSV" && !path.match("(/sap/bc/adt/vit)|(/sap/bc/esproxy)")
   }
   private _structure?: AbapObjectStructure
   public get structure(): AbapObjectStructure | undefined {

--- a/modules/abapObject/src/objectTypes/AbapXml.test.ts
+++ b/modules/abapObject/src/objectTypes/AbapXml.test.ts
@@ -1,0 +1,64 @@
+import { mock } from "jest-mock-extended"
+import { AbapObjectStructure } from "abap-adt-api"
+import { create } from "../creator"
+import { AbapObjectService } from "../AOService"
+import { isAbapXml } from "./AbapXml"
+
+describe.each([
+  ["DOMA/DD", "domains", "doma"],
+  ["DOMA/DO", "domains", "doma"],
+  ["TTYP/DA", "tabletypes", "ttyp"],
+  ["TTYP/TT", "tabletypes", "ttyp"]
+])("DDIC XML %s", (type, collection, extension) => {
+  const path = `/sap/bc/adt/ddic/${collection}/yexample`
+  const xml = '<?xml version="1.0" encoding="UTF-8"?><example/>'
+  const setup = () => {
+    const service = mock<AbapObjectService>()
+    const object = create(type, "YEXAMPLE", path, false, "YEXAMPLE", undefined, "", service)
+    return { service, object }
+  }
+
+  test("reads XML from the object endpoint without a text source link", async () => {
+    const { service, object } = setup()
+    service.getObjectSource.mockResolvedValue(xml)
+
+    expect(isAbapXml(object)).toBe(true)
+    expect(object.fsName).toBe(`YEXAMPLE.${extension}.xml`)
+    expect(object.canBeWritten).toBe(true)
+    expect(await object.read()).toBe(xml)
+    expect(service.getObjectSource).toHaveBeenCalledWith(path, undefined)
+  })
+
+  test("preserves the inactive version when reading", async () => {
+    const { service, object } = setup()
+    service.objectStructure.mockResolvedValue({
+      objectUrl: path,
+      metaData: mock<AbapObjectStructure["metaData"]>({ "adtcore:version": "inactive" }),
+      links: []
+    })
+    await object.loadStructure()
+    await object.read()
+    expect(service.getObjectSource).toHaveBeenCalledWith(path, "inactive")
+  })
+
+  test("writes unchanged XML using the lock and transport, then invalidates metadata", async () => {
+    const { service, object } = setup()
+    await object.write(xml, "lock-handle", "transport-request")
+    expect(service.setObjectSource).toHaveBeenCalledWith(
+      path,
+      xml,
+      "lock-handle",
+      "transport-request"
+    )
+    expect(service.invalidateStructCache).toHaveBeenCalledWith(path)
+    expect(object.lockObject).toBe(object)
+  })
+
+  test("propagates a rejected save without invalidating metadata", async () => {
+    const { service, object } = setup()
+    const error = new Error("Save rejected")
+    service.setObjectSource.mockRejectedValue(error)
+    await expect(object.write(xml, "lock-handle", "transport-request")).rejects.toBe(error)
+    expect(service.invalidateStructCache).not.toHaveBeenCalled()
+  })
+})

--- a/modules/abapObject/src/registry.ts
+++ b/modules/abapObject/src/registry.ts
@@ -273,26 +273,30 @@ const REGISTRY: ObjectTypeConfig[] = [
     label: "Table Type",
     gui_objects: "better",
     extension: ".ttyp.xml",
-    filterLabel: "Table Types"
+    filterLabel: "Table Types",
+    creatorClass: "AbapXml"
   },
   {
     type: "TTYP/TT",
     label: "Table Type",
     gui_objects: "better",
-    extension: ".ttyp.xml"
+    extension: ".ttyp.xml",
+    creatorClass: "AbapXml"
   },
   {
     type: "DOMA/DD",
     label: "Domain",
     gui_objects: "better",
     extension: ".doma.xml",
-    filterLabel: "Domains"
+    filterLabel: "Domains",
+    creatorClass: "AbapXml"
   },
   {
     type: "DOMA/DO",
     label: "Domain",
     gui_objects: "better",
-    extension: ".doma.xml"
+    extension: ".doma.xml",
+    creatorClass: "AbapXml"
   },
   {
     type: "VIEW/DV",


### PR DESCRIPTION
Domains currently resolve to the SAP GUI placeholder because their ADT paths are blocked in `AbapObjectBase`. Table types have XML extensions in the registry but no XML creator, so they fall through to the ABAP source handler and cannot resolve content when the metadata has no text source link.

Route `DOMA/DD`, `DOMA/DO`, `TTYP/DA`, and `TTYP/TT` through `AbapXml`, and remove the domain-specific block. Reads and writes then use the DDIC object endpoint with the existing lock, transport, inactive-version, and cache handling. Adds regression coverage for all four identifiers and a changeset.

Validation on Node 26.8.1: full `npm run build`, `npm run typecheck`, `npm test` (3,113 tests), and `npm run format:check` passed. The new 16 regression cases failed against the original routing and pass with this change. No SAP connection was configured for these local tests.

Live SAP validation passed on 2026-09-11 using a combined test build of this patch and the companion library patch: a previously created domain was edited through its XML workspace file to CHAR(10), saved and separately activated; a newly created table type was edited to use an existing Dictionary structure with standard access and a standard nonunique key, saved and separately activated. Fresh active XML and independent DDIC catalog reads confirmed both definitions. Both workspace editors resolved to their XML extensions. Table-type creation is a separate missing registration in `abap-adt-api`; this PR fixes the editing path independently and does not change the dependency version.

Related historical context: #8.